### PR TITLE
Python 2.5 compatibility

### DIFF
--- a/analytical/templatetags/google_analytics.py
+++ b/analytical/templatetags/google_analytics.py
@@ -36,6 +36,15 @@ CUSTOM_VAR_CODE = "_gaq.push(['_setCustomVar', %(index)s, '%(name)s', " \
 
 register = Library()
 
+def enumerate(sequence, start=0):
+    """
+    Port of 2.6's python enumerate() for compatibility with previos versions
+    """
+    n = start
+    for elem in sequence:
+        yield n, elem
+        n += 1
+
 
 @register.tag
 def google_analytics(parser, token):


### PR DESCRIPTION
Hi! In the code you are using `enumerate()` with a `start` parameter that was added in python 2.6... I added a port of 2.6's enumerate to the code. Hope it's usefull!
