### PR TITLE
Add basic support of Google gtag.js

### DIFF
--- a/analytical/templatetags/analytical.py
+++ b/analytical/templatetags/analytical.py
@@ -24,6 +24,7 @@ TAG_MODULES = [
     'analytical.gauges',
     'analytical.google_analytics',
     'analytical.google_analytics_js',
+    'analytical.google_analytics_gtag',
     'analytical.gosquared',
     'analytical.hotjar',
     'analytical.hubspot',

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -1,0 +1,65 @@
+"""
+Google Analytics template tags and filters, using the new analytics.js library.
+"""
+
+from __future__ import absolute_import
+
+import re
+
+from django.template import Library, Node, TemplateSyntaxError
+
+from analytical.utils import (
+    disable_html,
+    get_required_setting,
+    is_internal_ip,
+)
+
+PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$')
+SETUP_CODE = """
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={property_id}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{property_id}');
+</script>
+"""
+
+register = Library()
+
+
+@register.tag
+def google_analytics_gtag(parser, token):
+    """
+    Google Analytics tracking template tag.
+
+    Renders Javascript code to track page visits.  You must supply
+    your website property ID (as a string) in the
+    ``GOOGLE_ANALYTICS_JS_PROPERTY_ID`` setting.
+    """
+    bits = token.split_contents()
+    if len(bits) > 1:
+        raise TemplateSyntaxError("'%s' takes no arguments" % bits[0])
+    return GoogleAnalyticsGTagNode()
+
+
+class GoogleAnalyticsGTagNode(Node):
+    def __init__(self):
+        self.property_id = get_required_setting(
+            'GOOGLE_ANALYTICS_GTAG_PROPERTY_ID', PROPERTY_ID_RE,
+            "must be a string looking like 'UA-XXXXXX-Y'")
+
+    def render(self, context):
+        html = SETUP_CODE.format(
+            property_id=self.property_id,
+        )
+        if is_internal_ip(context, 'GOOGLE_ANALYTICS'):
+            html = disable_html(html, 'Google Analytics')
+        return html
+
+
+def contribute_to_analytical(add_node):
+    GoogleAnalyticsGTagNode()  # ensure properly configured
+    add_node('head_top', GoogleAnalyticsGTagNode)

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -16,11 +16,10 @@ from analytical.utils import (
 
 PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$')
 SETUP_CODE = """
-<!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={property_id}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
+  function gtag(){{dataLayer.push(arguments);}}
   gtag('js', new Date());
 
   gtag('config', '{property_id}');
@@ -37,7 +36,7 @@ def google_analytics_gtag(parser, token):
 
     Renders Javascript code to track page visits.  You must supply
     your website property ID (as a string) in the
-    ``GOOGLE_ANALYTICS_JS_PROPERTY_ID`` setting.
+    ``GOOGLE_ANALYTICS_GTAG_PROPERTY_ID`` setting.
     """
     bits = token.split_contents()
     if len(bits) > 1:

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -1,0 +1,48 @@
+"""
+Tests for the Google Analytics template tags and filters, using the new gtag.js library.
+"""
+
+from django.http import HttpRequest
+from django.template import Context
+from django.test.utils import override_settings
+
+from analytical.templatetags.google_analytics_gtag import GoogleAnalyticsGTagNode
+from analytical.tests.utils import TagTestCase
+from analytical.utils import AnalyticalException
+
+
+@override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='UA-123456-7')
+class GoogleAnalyticsTagTestCase(TagTestCase):
+    """
+    Tests for the ``google_analytics_js`` template tag.
+    """
+
+    def test_tag(self):
+        r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
+        self.assertTrue("""<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>""" in r, r)
+        self.assertTrue("gtag('js', new Date());" in r, r)
+        self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
+
+    def test_node(self):
+        r = GoogleAnalyticsGTagNode().render(Context())
+        self.assertTrue("""<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>""" in r, r)
+        self.assertTrue("gtag('js', new Date());" in r, r)
+        self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID=None)
+    def test_no_property_id(self):
+        self.assertRaises(AnalyticalException, GoogleAnalyticsGTagNode)
+
+    @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='wrong')
+    def test_wrong_property_id(self):
+        self.assertRaises(AnalyticalException, GoogleAnalyticsGTagNode)
+
+    @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
+    def test_render_internal_ip(self):
+        req = HttpRequest()
+        req.META['REMOTE_ADDR'] = '1.1.1.1'
+        context = Context({'request': req})
+        r = GoogleAnalyticsGTagNode().render(context)
+        self.assertTrue(r.startswith(
+            '<!-- Google Analytics disabled on internal IP address'), r)
+        self.assertTrue(r.endswith('-->'), r)

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -19,13 +19,17 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
-        self.assertTrue("""<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>""" in r, r)
+        self.assertTrue(
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
+            in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
 
     def test_node(self):
         r = GoogleAnalyticsGTagNode().render(Context())
-        self.assertTrue("""<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>""" in r, r)
+        self.assertTrue(
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
+            in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
 

--- a/docs/services/google_analytics_gtag.rst
+++ b/docs/services/google_analytics_gtag.rst
@@ -1,0 +1,80 @@
+======================================
+ Google Analytics -- traffic analysis
+======================================
+
+`Google Analytics`_ is the well-known web analytics service from
+Google.  The product is aimed more at marketers than webmasters or
+technologists, supporting integration with AdWords and other e-commence
+features.
+
+.. _`Google Analytics`: http://www.google.com/analytics/
+
+
+.. google-analytics-installation:
+
+Installation
+============
+
+To start using the Google Analytics integration, you must have installed
+the django-analytical package and have added the ``analytical``
+application to :const:`INSTALLED_APPS` in your project
+:file:`settings.py` file. See :doc:`../install` for details.
+
+Next you need to add the Google Analytics template tag to your
+templates. This step is only needed if you are not using the generic
+:ttag:`analytical.*` tags.  If you are, skip to
+:ref:`google-analytics-configuration`.
+
+The Google Analytics tracking code is inserted into templates using a
+template tag.  Load the :mod:`google_analytics_gtag` template tag library and
+insert the :ttag:`google_analytics_gtag` tag.  Because every page that you
+want to track must have the tag, it is useful to add it to your base
+template.  Insert the tag at the bottom of the HTML head::
+
+    {% load google_analytics_gtag %}
+    <html>
+    <head>
+    {% google_analytics_gtag %}
+    ...
+    </head>
+    ...
+
+
+.. _google-analytics-configuration:
+
+Configuration
+=============
+
+Before you can use the Google Analytics integration, you must first set
+your website property ID.  If you track multiple domains with the same
+code, you also need to set-up the domain.  Finally, you can add custom
+segments for Google Analytics to track.
+
+
+.. _google-analytics-property-id:
+
+Setting the property ID
+-----------------------
+
+Every website you track with Google Analytics gets its own property ID,
+and the :ttag:`google_analytics_gtag` tag will include it in the rendered
+Javascript code.  You can find the web property ID on the overview page
+of your account.  Set :const:`GOOGLE_ANALYTICS_GTAG_PROPERTY_ID` in the
+project :file:`settings.py` file::
+
+    GOOGLE_ANALYTICS_GTAG_PROPERTY_ID = 'UA-XXXXXX-X'
+
+If you do not set a property ID, the tracking code will not be rendered.
+
+
+
+Internal IP addresses
+---------------------
+
+Usually you do not want to track clicks from your development or
+internal IP addresses.  By default, if the tags detect that the client
+comes from any address in the :const:`GOOGLE_ANALYTICS_INTERNAL_IPS`
+setting, the tracking code is commented out.  It takes the value of
+:const:`ANALYTICAL_INTERNAL_IPS` by default (which in turn is
+:const:`INTERNAL_IPS` by default).  See :ref:`identifying-visitors` for
+important information about detecting the visitor IP address.


### PR DESCRIPTION
This PR adds the support of the the new [gtag.js](https://developers.google.com/analytics/devguides/collection/gtagjs/) library from Google.

It provides a new `google_analytics_gtag` tag, which is included if the `GOOGLE_ANALYTICS_GTAG_PROPERTY_ID` is set. There are yet not settings supported.