### PR TITLE
Fix flake8 and readme tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - { python: 3.4, env: DJANGO=2.1 }
   include:
     - { python: 3.6, env: TOXENV=flake8 }
-    - { python: 3.6, env: TOXENV=readme }
+    - { python: 3.6, env: TOXENV=readme, dist: xenial }  # requires sqlite3>=3.8.3 which is not in trusty
     # Work around Travis Python 3.7 issue: https://github.com/travis-ci/travis-ci/issues/9815
     - { python: 3.7, env: DJANGO=1.11, dist: xenial, sudo: true }
     - { python: 3.7, env: DJANGO=2.0, dist: xenial, sudo: true }

--- a/analytical/templatetags/intercom.py
+++ b/analytical/templatetags/intercom.py
@@ -8,8 +8,8 @@ import hashlib
 import hmac
 import json
 import sys
-import time
 import re
+import time
 
 from django.conf import settings
 from django.template import Library, Node, TemplateSyntaxError
@@ -29,7 +29,7 @@ TRACKING_CODE = """
 register = Library()
 
 
-def _timestamp(when):  # type: (datetime) -> float
+def _timestamp(when):
     """
     Python 2 compatibility for `datetime.timestamp()`.
     """
@@ -37,7 +37,7 @@ def _timestamp(when):  # type: (datetime) -> float
             when.timestamp())
 
 
-def _hashable_bytes(data):  # type: (AnyStr) -> bytes
+def _hashable_bytes(data):
     """
     Coerce strings to hashable bytes.
     """
@@ -49,7 +49,7 @@ def _hashable_bytes(data):  # type: (AnyStr) -> bytes
         raise TypeError(data)
 
 
-def intercom_user_hash(data):  # type: (AnyStr) -> Optional[str]
+def intercom_user_hash(data):
     """
     Return a SHA-256 HMAC `user_hash` as expected by Intercom, if configured.
 
@@ -117,9 +117,9 @@ class IntercomNode(Node):
         # (If both user_id and email are present, the user_id field takes precedence.)
         # See:
         # https://www.intercom.com/help/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product
-        user_hash_data = params.get('user_id', params.get('email'))  # type: Optional[str]
+        user_hash_data = params.get('user_id', params.get('email'))
         if user_hash_data:
-            user_hash = intercom_user_hash(str(user_hash_data))  # type: Optional[str]
+            user_hash = intercom_user_hash(str(user_hash_data))
             if user_hash is not None:
                 params.setdefault('user_hash', user_hash)
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,10 @@ deps = flake8
 commands = flake8
 
 [testenv:readme]
-deps = readme_renderer
-commands = python setup.py check --restructuredtext --strict
+deps = twine
+commands =
+    {envpython} setup.py -q sdist bdist_wheel
+    twine check dist/*
 
 [travis:env]
 DJANGO =
@@ -47,4 +49,5 @@ DJANGO =
     2.1: django21
 
 [flake8]
+exclude = .cache,.git,.tox,build,dist
 max-line-length = 100


### PR DESCRIPTION
This PR fixes two problems:
* Remove the typing hints from `intercom.py` because they cause warnings in flake8. We cannot import the typing names because they don't exist in Python 2.
* Use the xenial distribution for the readme test. Django now requires Sqlite version 3.8.3 or higher, which is not available on trusty.