### PR TITLE
Ensure Tox targets clean and docs are working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 /build
 /dist
+/docs/_build
 /MANIFEST
 
 /docs/_templates/layout.html

--- a/analytical/__init__.py
+++ b/analytical/__init__.py
@@ -5,5 +5,5 @@ Analytics service integration for Django projects
 __author__ = "Joost Cassee"
 __email__ = "joost@cassee.net"
 __version__ = "2.5.0"
-__copyright__ = "Copyright (C) 2011-2017 Joost Cassee and others"
-__license__ = "MIT License"
+__copyright__ = "Copyright (C) 2011-2019 Joost Cassee and contributors"
+__license__ = "MIT"

--- a/docs/_ext/local.py
+++ b/docs/_ext/local.py
@@ -19,8 +19,3 @@ def setup(app):
         rolename="lookup",
         indextemplate="pair: %s; field lookup type",
     )
-    app.add_description_unit(
-        directivename="decorator",
-        rolename="dec",
-        indextemplate="pair: %s; function decorator",
-    )

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     license=package.__license__,
     description=package.__doc__.strip(),
     long_description=read_file('README.rst'),
+    long_description_content_type='text/x-rst',
     author=package.__author__,
     author_email=package.__email__,
     packages=[
@@ -74,13 +75,9 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.7',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
@@ -99,7 +96,4 @@ setup(
     url='https://github.com/jazzband/django-analytical',
     download_url='https://github.com/jazzband/django-analytical/archive/master.zip',
     cmdclass=cmdclass,
-    install_requires=[
-        'Django>=1.7.0',
-    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -29,15 +29,14 @@ commands = bandit -r --ini tox.ini
 [testenv:clean]
 deps = pyclean
 commands =
-    rm -rf .tox/ django_analytical.egg-info/ build/ dist/ docs/_build/
     py3clean -v {toxinidir}
+    rm -rf .tox/ django_analytical.egg-info/ build/ dist/ docs/_build/
 whitelist_externals =
     rm
 
 [testenv:docs]
 deps = sphinx
-changedir = docs
-commands = make html
+commands = sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
 whitelist_externals = make
 
 [testenv:flake8]


### PR DESCRIPTION
* Ensure Tox target clean is working (execution order)
* Ensure Tox target docs is working (remove deprecated reference)
* Update packaging information (Django 2.2, license)
* Remove problematic install_requires from setup