### PR TITLE
docs: Fix simple typo, betweeen -> between

### DIFF
--- a/docs/services/matomo.rst
+++ b/docs/services/matomo.rst
@@ -98,7 +98,7 @@ other parameters should be strings. ::
     return some_template.render(context)
 
 Matomo default settings allow up to 5 custom variables for both scope. Variable
-mapping betweeen index and name must stay constant, or the latest name
+mapping between index and name must stay constant, or the latest name
 override the previous one.
 
 If you use the same user variables in different views and its value can

--- a/docs/services/piwik.rst
+++ b/docs/services/piwik.rst
@@ -107,7 +107,7 @@ other parameters should be strings. ::
     return some_template.render(context)
 
 Piwik default settings allow up to 5 custom variables for both scope. Variable
-mapping betweeen index and name must stay constant, or the latest name
+mapping between index and name must stay constant, or the latest name
 override the previous one.
 
 If you use the same user variables in different views and its value can


### PR DESCRIPTION
There is a small typo in docs/services/matomo.rst, docs/services/piwik.rst.

Should read `between` rather than `betweeen`.

