### PR TITLE
Add user_id to Google Analytics GTag

### DIFF
--- a/analytical/templatetags/analytical.py
+++ b/analytical/templatetags/analytical.py
@@ -72,8 +72,8 @@ class AnalyticalNode(Node):
 
 
 def _load_template_nodes():
-    template_nodes = dict((l, dict((p, []) for p in TAG_POSITIONS))
-                          for l in TAG_LOCATIONS)
+    template_nodes = dict((loc, dict((pos, []) for pos in TAG_POSITIONS))
+                          for loc in TAG_LOCATIONS)
 
     def add_node_cls(location, node, position=None):
         template_nodes[location][position].append(node)

--- a/analytical/tests/templatetags/dummy.py
+++ b/analytical/tests/templatetags/dummy.py
@@ -19,7 +19,7 @@ def _location_node(location):
     return DummyNode
 
 
-_location_nodes = dict((l, _location_node(l)) for l in TAG_LOCATIONS)
+_location_nodes = dict((loc, _location_node(loc)) for loc in TAG_LOCATIONS)
 
 
 def _location_tag(location):

--- a/analytical/tests/test_tag_analytical.py
+++ b/analytical/tests/test_tag_analytical.py
@@ -31,6 +31,6 @@ class AnalyticsTagTestCase(TagTestCase):
         return t.render(Context(vars))
 
     def test_location_tags(self):
-        for l in ['head_top', 'head_bottom', 'body_top', 'body_bottom']:
-            r = self.render_location_tag(l)
-            self.assertTrue('dummy_%s' % l in r, r)
+        for loc in ['head_top', 'head_bottom', 'body_top', 'body_bottom']:
+            r = self.render_location_tag(loc)
+            self.assertTrue('dummy_%s' % loc in r, r)

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -2,6 +2,7 @@
 Tests for the Google Analytics template tags and filters, using the new gtag.js library.
 """
 
+from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.template import Context
 from django.test.utils import override_settings
@@ -50,3 +51,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         self.assertTrue(r.startswith(
             '<!-- Google Analytics disabled on internal IP address'), r)
         self.assertTrue(r.endswith('-->'), r)
+
+    @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
+    def test_identify(self):
+        r = GoogleAnalyticsGTagNode().render(Context({'user': User(username='test')}))
+        self.assertTrue("gtag('set', {'user_id': 'test'});" in r, r)

--- a/docs/services/google_analytics_gtag.rst
+++ b/docs/services/google_analytics_gtag.rst
@@ -81,3 +81,11 @@ setting, the tracking code is commented out.  It takes the value of
 :const:`ANALYTICAL_INTERNAL_IPS` by default (which in turn is
 :const:`INTERNAL_IPS` by default).  See :ref:`identifying-visitors` for
 important information about detecting the visitor IP address.
+
+.. _google-analytics-identify-user:
+
+Identifying authenticated users
+-------------------------------
+
+The username of an authenticated user is passed to Google Analytics
+automatically as the `user_id`.  See :ref:`identifying-visitors`.


### PR DESCRIPTION
This commit adds user_id support for the gtag google analytics implementation.