### PR TITLE
Updated regex for gtag to accept measurement ID

### DIFF
--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -15,7 +15,7 @@ from analytical.utils import (
     is_internal_ip,
 )
 
-PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$|^G-[a-zA-Z0-9]+$')
+PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$|^G-[a-zA-Z0-9]+$|^AW-[a-zA-Z0-9]+$|^DC-[a-zA-Z0-9]+$')
 SETUP_CODE = """
 <script async src="https://www.googletagmanager.com/gtag/js?id={property_id}"></script>
 <script>
@@ -52,7 +52,7 @@ class GoogleAnalyticsGTagNode(Node):
     def __init__(self):
         self.property_id = get_required_setting(
             'GOOGLE_ANALYTICS_GTAG_PROPERTY_ID', PROPERTY_ID_RE,
-            "must be a string looking like 'UA-XXXXXX-Y'")
+            "must be a string looking like one of these patterns ('UA-XXXXXX-Y' , 'AW-XXXXXXXXXX', 'G-XXXXXXXX', 'DC-XXXXXXXX')")
 
     def render(self, context):
         other_fields = {}

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -52,8 +52,8 @@ class GoogleAnalyticsGTagNode(Node):
     def __init__(self):
         self.property_id = get_required_setting(
             'GOOGLE_ANALYTICS_GTAG_PROPERTY_ID', PROPERTY_ID_RE,
-            '''must be a string looking like one of these patterns 
-            ('UA-XXXXXX-Y' , 'AW-XXXXXXXXXX', 
+            '''must be a string looking like one of these patterns
+            ('UA-XXXXXX-Y' , 'AW-XXXXXXXXXX',
             'G-XXXXXXXX', 'DC-XXXXXXXX')''')
 
     def render(self, context):

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -15,7 +15,7 @@ from analytical.utils import (
     is_internal_ip,
 )
 
-PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$')
+PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$|^G-[a-zA-Z0-9]+$')
 SETUP_CODE = """
 <script async src="https://www.googletagmanager.com/gtag/js?id={property_id}"></script>
 <script>

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -52,7 +52,9 @@ class GoogleAnalyticsGTagNode(Node):
     def __init__(self):
         self.property_id = get_required_setting(
             'GOOGLE_ANALYTICS_GTAG_PROPERTY_ID', PROPERTY_ID_RE,
-            "must be a string looking like one of these patterns ('UA-XXXXXX-Y' , 'AW-XXXXXXXXXX', 'G-XXXXXXXX', 'DC-XXXXXXXX')")
+            '''must be a string looking like one of these patterns 
+            ('UA-XXXXXX-Y' , 'AW-XXXXXXXXXX', 
+            'G-XXXXXXXX', 'DC-XXXXXXXX')''')
 
     def render(self, context):
         other_fields = {}

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -56,3 +56,30 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_identify(self):
         r = GoogleAnalyticsGTagNode().render(Context({'user': User(username='test')}))
         self.assertTrue("gtag('set', {'user_id': 'test'});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='G-12345678')
+    def test_tag_with_measurement_id(self):
+        r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
+        self.assertTrue(
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=G-12345678"></script>'
+            in r, r)
+        self.assertTrue("gtag('js', new Date());" in r, r)
+        self.assertTrue("gtag('config', 'G-12345678');" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='AW-1234567890')
+    def test_tag_with_conversion_id(self):
+        r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
+        self.assertTrue(
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1234567890"></script>'
+            in r, r)
+        self.assertTrue("gtag('js', new Date());" in r, r)
+        self.assertTrue("gtag('config', 'AW-1234567890');" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='DC-12345678')
+    def test_tag_with_advertiser_id(self):
+        r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
+        self.assertTrue(
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=DC-12345678"></script>'
+            in r, r)
+        self.assertTrue("gtag('js', new Date());" in r, r)
+        self.assertTrue("gtag('config', 'DC-12345678');" in r, r)

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -62,7 +62,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
             ('<script async src="https://www.googletagmanager.com/gtag/' +
-                 'js?id=G-12345678"></script>')
+             'js?id=G-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'G-12345678');" in r, r)
@@ -72,7 +72,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
             ('<script async src="https://www.googletagmanager.com/gtag/' +
-                 'js?id=AW-1234567890"></script>')
+             'js?id=AW-1234567890"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'AW-1234567890');" in r, r)
@@ -82,8 +82,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
             ('<script async src="https://www.googletagmanager.com/gtag/' +
-                 'js?id=DC-12345678"></script>')
+             'js?id=DC-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'DC-12345678');" in r, r)
-

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -61,7 +61,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_measurement_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            '<script async src="https://www.googletagmanager.com/gtag/js?id=G-12345678"></script>'
+            ('<script async src="https://www.googletagmanager.com/gtag/'+
+                'js?id=G-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'G-12345678');" in r, r)
@@ -70,7 +71,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_conversion_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            '<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1234567890"></script>'
+            ('<script async src="https://www.googletagmanager.com/gtag/'+
+                'js?id=AW-1234567890"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'AW-1234567890');" in r, r)
@@ -79,7 +81,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_advertiser_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            '<script async src="https://www.googletagmanager.com/gtag/js?id=DC-12345678"></script>'
+            ('<script async src="https://www.googletagmanager.com/gtag/'+
+                'js?id=DC-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'DC-12345678');" in r, r)

--- a/analytical/tests/test_tag_google_analytics_gtag.py
+++ b/analytical/tests/test_tag_google_analytics_gtag.py
@@ -61,8 +61,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_measurement_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/'+
-                'js?id=G-12345678"></script>')
+            ('<script async src="https://www.googletagmanager.com/gtag/' +
+                 'js?id=G-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'G-12345678');" in r, r)
@@ -71,8 +71,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_conversion_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/'+
-                'js?id=AW-1234567890"></script>')
+            ('<script async src="https://www.googletagmanager.com/gtag/' +
+                 'js?id=AW-1234567890"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'AW-1234567890');" in r, r)
@@ -81,8 +81,9 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_tag_with_advertiser_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
         self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/'+
-                'js?id=DC-12345678"></script>')
+            ('<script async src="https://www.googletagmanager.com/gtag/' +
+                 'js?id=DC-12345678"></script>')
             in r, r)
         self.assertTrue("gtag('js', new Date());" in r, r)
         self.assertTrue("gtag('config', 'DC-12345678');" in r, r)
+

--- a/docs/services/google_analytics_gtag.rst
+++ b/docs/services/google_analytics_gtag.rst
@@ -69,6 +69,12 @@ project :file:`settings.py` file::
 
 If you do not set a property ID, the tracking code will not be rendered.
 
+Please node that the accepted Property IDs should be one of the following formats:
+
+- 'UA-XXXXXX-Y'
+- 'AW-XXXXXXXXXX'
+- 'G-XXXXXXXX'
+- 'DC-XXXXXXXX'
 
 
 Internal IP addresses


### PR DESCRIPTION
The new App+Web feature of Google Analytics uses Measurement ID, which has a different pattern then UA property ID. Currently the code was not accepting measurement IDs due to a regex check which I have changed to incorporate the Measurement ID pattern.

Fixes #163 