### PR TITLE
Add SnapEngage details to Installation section

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -185,6 +185,10 @@ settings required to enable each service are listed here:
 
     RATING_MAILRU_COUNTER_ID = '1234567'
 
+* :doc:`SnapEngage <services/snapengage>`::
+
+    SNAPENGAGE_WIDGET_ID = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+
 * :doc:`Woopra <services/woopra>`::
 
     WOOPRA_DOMAIN = 'abcde.com'


### PR DESCRIPTION
Adds the missing details on SnapEngage to the [Installation and configuration](https://django-analytical.readthedocs.io/en/latest/install.html) section of the docs.

Thanks @johnmathews for bringing this to our attention!

Fixes #166