### PR TITLE
Add missing Google Analytics instructions to install section

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -133,9 +133,17 @@ settings required to enable each service are listed here:
 
     GAUGES_SITE_ID = '0123456789abcdef0123456789abcdef'
 
-* :doc:`Google Analytics <services/google_analytics>`::
+* :doc:`Google Analytics (legacy) <services/google_analytics>`::
 
     GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-1234567-8'
+
+* :doc:`Google Analytics (gtag.js) <services/google_analytics_gtag>`::
+
+    GOOGLE_ANALYTICS_GTAG_PROPERTY_ID = 'UA-1234567-8'
+
+* :doc:`Google Analytics (analytics.js) <services/google_analytics_js>`::
+
+    GOOGLE_ANALYTICS_JS_PROPERTY_ID = 'UA-12345678-9'
 
 * :doc:`HubSpot <services/hubspot>`::
 

--- a/docs/services/google_analytics_js.rst
+++ b/docs/services/google_analytics_js.rst
@@ -65,7 +65,7 @@ Javascript code.  You can find the web property ID on the overview page
 of your account.  Set :const:`GOOGLE_ANALYTICS_JS_PROPERTY_ID` in the
 project :file:`settings.py` file::
 
-    GOOGLE_ANALYTICS_JS_PROPERTY_ID = 'UA-XXXXXX-X'
+    GOOGLE_ANALYTICS_JS_PROPERTY_ID = 'UA-XXXXXXXX-X'
 
 If you do not set a property ID, the tracking code will not be rendered.
 


### PR DESCRIPTION
Similar to #166, it seems like both Google Analytics Universal Analytics and Google Analytics JS integration have been added w/o extending the [install section](https://django-analytical.readthedocs.io/en/latest/install.html#enabling-the-services) in our docs.