### PR TITLE
Migrate tests to Pytest plain asserts

### DIFF
--- a/tests/unit/test_tag_analytical.py
+++ b/tests/unit/test_tag_analytical.py
@@ -33,4 +33,4 @@ class AnalyticsTagTestCase(TagTestCase):
     def test_location_tags(self):
         for loc in ['head_top', 'head_bottom', 'body_top', 'body_bottom']:
             r = self.render_location_tag(loc)
-            self.assertTrue('dummy_%s' % loc in r, r)
+            assert f'dummy_{loc}' in r

--- a/tests/unit/test_tag_chartbeat.py
+++ b/tests/unit/test_tag_chartbeat.py
@@ -39,8 +39,8 @@ class ChartbeatTagTestCaseWithSites(TestCase):
         site = Site.objects.create(domain="test.com", name="test")
         with override_settings(SITE_ID=site.id):
             r = ChartbeatBottomNode().render(Context())
-            self.assertTrue(re.search('var _sf_async_config={.*"uid": "12345".*};', r), r)
-            self.assertTrue(re.search('var _sf_async_config={.*"domain": "test.com".*};', r), r)
+            assert re.search('var _sf_async_config={.*"uid": "12345".*};', r)
+            assert re.search('var _sf_async_config={.*"domain": "test.com".*};', r)
 
     @override_settings(CHARTBEAT_AUTO_DOMAIN=False)
     def test_auto_domain_false(self):
@@ -50,7 +50,7 @@ class ChartbeatTagTestCaseWithSites(TestCase):
         in _sf_async_config.
         """
         r = ChartbeatBottomNode().render(Context())
-        self.assertTrue('var _sf_async_config={"uid": "12345"};' in r, r)
+        assert 'var _sf_async_config={"uid": "12345"};' in r
 
 
 @override_settings(CHARTBEAT_USER_ID='12345')
@@ -61,25 +61,25 @@ class ChartbeatTagTestCase(TagTestCase):
 
     def test_top_tag(self):
         r = self.render_tag('chartbeat', 'chartbeat_top', {'chartbeat_domain': "test.com"})
-        self.assertTrue('var _sf_startpt=(new Date()).getTime()' in r, r)
+        assert 'var _sf_startpt=(new Date()).getTime()' in r
 
     def test_bottom_tag(self):
         r = self.render_tag('chartbeat', 'chartbeat_bottom', {'chartbeat_domain': "test.com"})
-        self.assertTrue(re.search('var _sf_async_config={.*"uid": "12345".*};', r), r)
-        self.assertTrue(re.search('var _sf_async_config={.*"domain": "test.com".*};', r), r)
+        assert re.search('var _sf_async_config={.*"uid": "12345".*};', r)
+        assert re.search('var _sf_async_config={.*"domain": "test.com".*};', r)
 
     def test_top_node(self):
         r = ChartbeatTopNode().render(Context({
             'chartbeat_domain': "test.com",
         }))
-        self.assertTrue('var _sf_startpt=(new Date()).getTime()' in r, r)
+        assert 'var _sf_startpt=(new Date()).getTime()' in r
 
     def test_bottom_node(self):
         r = ChartbeatBottomNode().render(Context({
             'chartbeat_domain': "test.com",
         }))
-        self.assertTrue(re.search('var _sf_async_config={.*"uid": "12345".*};', r), r)
-        self.assertTrue(re.search('var _sf_async_config={.*"domain": "test.com".*};', r), r)
+        assert re.search('var _sf_async_config={.*"uid": "12345".*};', r)
+        assert re.search('var _sf_async_config={.*"domain": "test.com".*};', r)
 
     @override_settings(CHARTBEAT_USER_ID=None)
     def test_no_user_id(self):
@@ -95,6 +95,5 @@ class ChartbeatTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = ChartbeatBottomNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Chartbeat disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Chartbeat disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_chartbeat.py
+++ b/tests/unit/test_tag_chartbeat.py
@@ -14,6 +14,8 @@ from analytical.templatetags.chartbeat import ChartbeatTopNode, \
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(CHARTBEAT_USER_ID='12345')
 class ChartbeatTagTestCaseNoSites(TestCase):
@@ -83,11 +85,13 @@ class ChartbeatTagTestCase(TagTestCase):
 
     @override_settings(CHARTBEAT_USER_ID=None)
     def test_no_user_id(self):
-        self.assertRaises(AnalyticalException, ChartbeatBottomNode)
+        with pytest.raises(AnalyticalException):
+            ChartbeatBottomNode()
 
     @override_settings(CHARTBEAT_USER_ID='123abc')
     def test_wrong_user_id(self):
-        self.assertRaises(AnalyticalException, ChartbeatBottomNode)
+        with pytest.raises(AnalyticalException):
+            ChartbeatBottomNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):

--- a/tests/unit/test_tag_clickmap.py
+++ b/tests/unit/test_tag_clickmap.py
@@ -10,6 +10,8 @@ from analytical.templatetags.clickmap import ClickmapNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(CLICKMAP_TRACKER_ID='12345ABC')
 class ClickmapTagTestCase(TagTestCase):
@@ -27,11 +29,13 @@ class ClickmapTagTestCase(TagTestCase):
 
     @override_settings(CLICKMAP_TRACKER_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, ClickmapNode)
+        with pytest.raises(AnalyticalException):
+            ClickmapNode()
 
     @override_settings(CLICKMAP_TRACKER_ID='ab#c')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, ClickmapNode)
+        with pytest.raises(AnalyticalException):
+            ClickmapNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):

--- a/tests/unit/test_tag_clickmap.py
+++ b/tests/unit/test_tag_clickmap.py
@@ -19,11 +19,11 @@ class ClickmapTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('clickmap', 'clickmap')
-        self.assertTrue("tracker: '12345ABC', version:'2'};" in r, r)
+        assert "tracker: '12345ABC', version:'2'};" in r
 
     def test_node(self):
         r = ClickmapNode().render(Context({}))
-        self.assertTrue("tracker: '12345ABC', version:'2'};" in r, r)
+        assert "tracker: '12345ABC', version:'2'};" in r
 
     @override_settings(CLICKMAP_TRACKER_ID=None)
     def test_no_site_id(self):
@@ -39,6 +39,5 @@ class ClickmapTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = ClickmapNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Clickmap disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Clickmap disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_clicky.py
+++ b/tests/unit/test_tag_clicky.py
@@ -13,6 +13,8 @@ from analytical.templatetags.clicky import ClickyNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(CLICKY_SITE_ID='12345678')
 class ClickyTagTestCase(TagTestCase):
@@ -32,11 +34,13 @@ class ClickyTagTestCase(TagTestCase):
 
     @override_settings(CLICKY_SITE_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, ClickyNode)
+        with pytest.raises(AnalyticalException):
+            ClickyNode()
 
     @override_settings(CLICKY_SITE_ID='123abc')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, ClickyNode)
+        with pytest.raises(AnalyticalException):
+            ClickyNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):

--- a/tests/unit/test_tag_clicky.py
+++ b/tests/unit/test_tag_clicky.py
@@ -22,13 +22,13 @@ class ClickyTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('clicky', 'clicky')
-        self.assertTrue('clicky_site_ids.push(12345678);' in r, r)
-        self.assertTrue('src="//in.getclicky.com/12345678ns.gif"' in r, r)
+        assert 'clicky_site_ids.push(12345678);' in r
+        assert 'src="//in.getclicky.com/12345678ns.gif"' in r
 
     def test_node(self):
         r = ClickyNode().render(Context({}))
-        self.assertTrue('clicky_site_ids.push(12345678);' in r, r)
-        self.assertTrue('src="//in.getclicky.com/12345678ns.gif"' in r, r)
+        assert 'clicky_site_ids.push(12345678);' in r
+        assert 'src="//in.getclicky.com/12345678ns.gif"' in r
 
     @override_settings(CLICKY_SITE_ID=None)
     def test_no_site_id(self):
@@ -41,21 +41,19 @@ class ClickyTagTestCase(TagTestCase):
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = ClickyNode().render(Context({'user': User(username='test')}))
-        self.assertTrue('var clicky_custom = {"session": {"username": "test"}};' in r, r)
+        assert 'var clicky_custom = {"session": {"username": "test"}};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = ClickyNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse('var clicky_custom = {"session": {"username":' in r, r)
+        assert 'var clicky_custom = {"session": {"username":' not in r
 
     def test_custom(self):
         r = ClickyNode().render(Context({
             'clicky_var1': 'val1',
             'clicky_var2': 'val2',
         }))
-        self.assertTrue(
-            re.search(r'var clicky_custom = {.*"var1": "val1", "var2": "val2".*};', r),
-            r)
+        assert re.search(r'var clicky_custom = {.*"var1": "val1", "var2": "val2".*};', r)
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -63,6 +61,5 @@ class ClickyTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = ClickyNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Clicky disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Clicky disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_crazy_egg.py
+++ b/tests/unit/test_tag_crazy_egg.py
@@ -19,11 +19,11 @@ class CrazyEggTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('crazy_egg', 'crazy_egg')
-        self.assertTrue('/1234/5678.js' in r, r)
+        assert '/1234/5678.js' in r
 
     def test_node(self):
         r = CrazyEggNode().render(Context())
-        self.assertTrue('/1234/5678.js' in r, r)
+        assert '/1234/5678.js' in r
 
     @override_settings(CRAZY_EGG_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
@@ -36,8 +36,8 @@ class CrazyEggTagTestCase(TagTestCase):
     def test_uservars(self):
         context = Context({'crazy_egg_var1': 'foo', 'crazy_egg_var2': 'bar'})
         r = CrazyEggNode().render(context)
-        self.assertTrue("CE2.set(1, 'foo');" in r, r)
-        self.assertTrue("CE2.set(2, 'bar');" in r, r)
+        assert "CE2.set(1, 'foo');" in r
+        assert "CE2.set(2, 'bar');" in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -45,6 +45,5 @@ class CrazyEggTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = CrazyEggNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Crazy Egg disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Crazy Egg disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_crazy_egg.py
+++ b/tests/unit/test_tag_crazy_egg.py
@@ -5,6 +5,7 @@ Tests for the Crazy Egg template tags and filters.
 from django.http import HttpRequest
 from django.template import Context
 from django.test.utils import override_settings
+import pytest
 
 from analytical.templatetags.crazy_egg import CrazyEggNode
 from utils import TagTestCase
@@ -27,11 +28,13 @@ class CrazyEggTagTestCase(TagTestCase):
 
     @override_settings(CRAZY_EGG_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
-        self.assertRaises(AnalyticalException, CrazyEggNode)
+        with pytest.raises(AnalyticalException):
+            CrazyEggNode()
 
     @override_settings(CRAZY_EGG_ACCOUNT_NUMBER='123abc')
     def test_wrong_account_number(self):
-        self.assertRaises(AnalyticalException, CrazyEggNode)
+        with pytest.raises(AnalyticalException):
+            CrazyEggNode()
 
     def test_uservars(self):
         context = Context({'crazy_egg_var1': 'foo', 'crazy_egg_var2': 'bar'})

--- a/tests/unit/test_tag_gauges.py
+++ b/tests/unit/test_tag_gauges.py
@@ -10,6 +10,8 @@ from analytical.templatetags.gauges import GaugesNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(GAUGES_SITE_ID='1234567890abcdef0123456789')
 class GaugesTagTestCase(TagTestCase):
@@ -18,7 +20,7 @@ class GaugesTagTestCase(TagTestCase):
     """
 
     def test_tag(self):
-        self.assertEqual("""
+        assert self.render_tag('gauges', 'gauges') == """
     <script type="text/javascript">
       var _gauges = _gauges || [];
       (function() {
@@ -32,11 +34,10 @@ class GaugesTagTestCase(TagTestCase):
         s.parentNode.insertBefore(t, s);
       })();
     </script>
-""", self.render_tag('gauges', 'gauges'))
+"""
 
     def test_node(self):
-        self.assertEqual(
-                """
+        assert GaugesNode().render(Context()) == """
     <script type="text/javascript">
       var _gauges = _gauges || [];
       (function() {
@@ -50,11 +51,12 @@ class GaugesTagTestCase(TagTestCase):
         s.parentNode.insertBefore(t, s);
       })();
     </script>
-""", GaugesNode().render(Context()))
+"""
 
     @override_settings(GAUGES_SITE_ID=None)
     def test_no_account_number(self):
-        self.assertRaises(AnalyticalException, GaugesNode)
+        with pytest.raises(AnalyticalException):
+            GaugesNode()
 
     @override_settings(GAUGES_SITE_ID='123abQ')
     def test_wrong_account_number(self):
@@ -66,6 +68,5 @@ class GaugesTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = GaugesNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Gauges disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Gauges disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_google_analytics.py
+++ b/tests/unit/test_tag_google_analytics.py
@@ -12,6 +12,8 @@ from analytical.templatetags.google_analytics import GoogleAnalyticsNode, \
 from utils import TestCase, TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
                    GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_SINGLE_DOMAIN)
@@ -22,36 +24,38 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('google_analytics', 'google_analytics')
-        self.assertTrue("_gaq.push(['_setAccount', 'UA-123456-7']);" in r, r)
-        self.assertTrue("_gaq.push(['_trackPageview']);" in r, r)
+        assert "_gaq.push(['_setAccount', 'UA-123456-7']);" in r
+        assert "_gaq.push(['_trackPageview']);" in r
 
     def test_node(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setAccount', 'UA-123456-7']);" in r, r)
-        self.assertTrue("_gaq.push(['_trackPageview']);" in r, r)
+        assert "_gaq.push(['_setAccount', 'UA-123456-7']);" in r
+        assert "_gaq.push(['_trackPageview']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID=None)
     def test_no_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode()
 
     @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='wrong')
     def test_wrong_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode()
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_SUBDOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_subdomains(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setDomainName', 'example.com']);" in r, r)
-        self.assertTrue("_gaq.push(['_setAllowHash', false]);" in r, r)
+        assert "_gaq.push(['_setDomainName', 'example.com']);" in r
+        assert "_gaq.push(['_setAllowHash', false]);" in r
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_domains(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setDomainName', 'example.com']);" in r, r)
-        self.assertTrue("_gaq.push(['_setAllowHash', false]);" in r, r)
-        self.assertTrue("_gaq.push(['_setAllowLinker', true]);" in r, r)
+        assert "_gaq.push(['_setDomainName', 'example.com']);" in r
+        assert "_gaq.push(['_setAllowHash', false]);" in r
+        assert "_gaq.push(['_setAllowLinker', true]);" in r
 
     def test_custom_vars(self):
         context = Context({
@@ -61,23 +65,23 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             'google_analytics_var5': ('test5', 'qux', SCOPE_PAGE),
         })
         r = GoogleAnalyticsNode().render(context)
-        self.assertTrue("_gaq.push(['_setCustomVar', 1, 'test1', 'foo', 3]);" in r, r)
-        self.assertTrue("_gaq.push(['_setCustomVar', 2, 'test2', 'bar', 1]);" in r, r)
-        self.assertTrue("_gaq.push(['_setCustomVar', 4, 'test4', 'baz', 2]);" in r, r)
-        self.assertTrue("_gaq.push(['_setCustomVar', 5, 'test5', 'qux', 3]);" in r, r)
+        assert "_gaq.push(['_setCustomVar', 1, 'test1', 'foo', 3]);" in r
+        assert "_gaq.push(['_setCustomVar', 2, 'test2', 'bar', 1]);" in r
+        assert "_gaq.push(['_setCustomVar', 4, 'test4', 'baz', 2]);" in r
+        assert "_gaq.push(['_setCustomVar', 5, 'test5', 'qux', 3]);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED=True)
     def test_track_page_load_time(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_trackPageLoadTime']);" in r, r)
+        assert "_gaq.push(['_trackPageLoadTime']);" in r
 
     def test_display_advertising(self):
         with override_settings(GOOGLE_ANALYTICS_DISPLAY_ADVERTISING=False):
             r = GoogleAnalyticsNode().render(Context())
-            self.assertTrue("google-analytics.com/ga.js" in r, r)
+            assert "google-analytics.com/ga.js" in r
         with override_settings(GOOGLE_ANALYTICS_DISPLAY_ADVERTISING=True):
             r = GoogleAnalyticsNode().render(Context())
-            self.assertTrue("stats.g.doubleclick.net/dc.js" in r, r)
+            assert "stats.g.doubleclick.net/dc.js" in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -85,90 +89,95 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = GoogleAnalyticsNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Google Analytics disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Google Analytics disabled on internal IP address')
+        assert r.endswith('-->')
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=True)
     def test_anonymize_ip(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_gat._anonymizeIp']);" in r, r)
-        self.assertTrue(r.index('_gat._anonymizeIp') < r.index('_trackPageview'), r)
+        assert "_gaq.push(['_gat._anonymizeIp']);" in r
+        assert r.index('_gat._anonymizeIp') < r.index('_trackPageview')
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=False)
     def test_anonymize_ip_not_present(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertFalse("_gaq.push(['_gat._anonymizeIp']);" in r, r)
+        assert "_gaq.push(['_gat._anonymizeIp']);" not in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=0.0)
     def test_set_sample_rate_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSampleRate', '0.00']);" in r, r)
+        assert "_gaq.push(['_setSampleRate', '0.00']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE='100.00')
     def test_set_sample_rate_max(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSampleRate', '100.00']);" in r, r)
+        assert "_gaq.push(['_setSampleRate', '100.00']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=-1)
     def test_exception_whenset_sample_rate_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=101)
     def test_exception_when_set_sample_rate_too_large(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
     def test_set_site_speed_sample_rate_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSiteSpeedSampleRate', '0.00']);" in r, r)
+        assert "_gaq.push(['_setSiteSpeedSampleRate', '0.00']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
     def test_set_site_speed_sample_rate_max(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSiteSpeedSampleRate', '100.00']);" in r, r)
+        assert "_gaq.push(['_setSiteSpeedSampleRate', '100.00']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
     def test_exception_whenset_site_speed_sample_rate_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=101)
     def test_exception_when_set_site_speed_sample_rate_too_large(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT=0)
     def test_set_session_cookie_timeout_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSessionCookieTimeout', '0']);" in r, r)
+        assert "_gaq.push(['_setSessionCookieTimeout', '0']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT='10000')
     def test_set_session_cookie_timeout_as_string(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setSessionCookieTimeout', '10000']);" in r, r)
+        assert "_gaq.push(['_setSessionCookieTimeout', '10000']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT=-1)
     def test_exception_when_set_session_cookie_timeout_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT=0)
     def test_set_visitor_cookie_timeout_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setVisitorCookieTimeout', '0']);" in r, r)
+        assert "_gaq.push(['_setVisitorCookieTimeout', '0']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT='10000')
     def test_set_visitor_cookie_timeout_as_string(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push(['_setVisitorCookieTimeout', '10000']);" in r, r)
+        assert "_gaq.push(['_setVisitorCookieTimeout', '10000']);" in r
 
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT=-1)
     def test_exception_when_set_visitor_cookie_timeout_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)
 
 
 @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
@@ -178,4 +187,5 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 class NoDomainTestCase(TestCase):
     def test_exception_without_domain(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsNode().render(context)

--- a/tests/unit/test_tag_google_analytics_gtag.py
+++ b/tests/unit/test_tag_google_analytics_gtag.py
@@ -11,6 +11,8 @@ from analytical.templatetags.google_analytics_gtag import GoogleAnalyticsGTagNod
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='UA-123456-7')
 class GoogleAnalyticsTagTestCase(TagTestCase):
@@ -20,27 +22,29 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
-        self.assertTrue(
+        assert (
             '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
-            in r, r)
-        self.assertTrue("gtag('js', new Date());" in r, r)
-        self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
+        ) in r
+        assert "gtag('js', new Date());" in r
+        assert "gtag('config', 'UA-123456-7');" in r
 
     def test_node(self):
         r = GoogleAnalyticsGTagNode().render(Context())
-        self.assertTrue(
+        assert (
             '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
-            in r, r)
-        self.assertTrue("gtag('js', new Date());" in r, r)
-        self.assertTrue("gtag('config', 'UA-123456-7');" in r, r)
+        ) in r
+        assert "gtag('js', new Date());" in r
+        assert "gtag('config', 'UA-123456-7');" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID=None)
     def test_no_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsGTagNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsGTagNode()
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='wrong')
     def test_wrong_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsGTagNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsGTagNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -48,41 +52,37 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = GoogleAnalyticsGTagNode().render(context)
-        self.assertTrue(r.startswith(
-            '<!-- Google Analytics disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Google Analytics disabled on internal IP address')
+        assert r.endswith('-->')
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = GoogleAnalyticsGTagNode().render(Context({'user': User(username='test')}))
-        self.assertTrue("gtag('set', {'user_id': 'test'});" in r, r)
+        assert "gtag('set', {'user_id': 'test'});" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='G-12345678')
     def test_tag_with_measurement_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
-        self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/' +
-             'js?id=G-12345678"></script>')
-            in r, r)
-        self.assertTrue("gtag('js', new Date());" in r, r)
-        self.assertTrue("gtag('config', 'G-12345678');" in r, r)
+        assert (
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=G-12345678"></script>'
+        ) in r
+        assert "gtag('js', new Date());" in r
+        assert "gtag('config', 'G-12345678');" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='AW-1234567890')
     def test_tag_with_conversion_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
-        self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/' +
-             'js?id=AW-1234567890"></script>')
-            in r, r)
-        self.assertTrue("gtag('js', new Date());" in r, r)
-        self.assertTrue("gtag('config', 'AW-1234567890');" in r, r)
+        assert (
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1234567890"></script'
+        ) in r
+        assert "gtag('js', new Date());" in r
+        assert "gtag('config', 'AW-1234567890');" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='DC-12345678')
     def test_tag_with_advertiser_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')
-        self.assertTrue(
-            ('<script async src="https://www.googletagmanager.com/gtag/' +
-             'js?id=DC-12345678"></script>')
-            in r, r)
-        self.assertTrue("gtag('js', new Date());" in r, r)
-        self.assertTrue("gtag('config', 'DC-12345678');" in r, r)
+        assert (
+            '<script async src="https://www.googletagmanager.com/gtag/js?id=DC-12345678"></script>'
+        ) in r
+        assert "gtag('js', new Date());" in r
+        assert "gtag('config', 'DC-12345678');" in r

--- a/tests/unit/test_tag_google_analytics_js.py
+++ b/tests/unit/test_tag_google_analytics_js.py
@@ -11,6 +11,8 @@ from analytical.templatetags.google_analytics_js import GoogleAnalyticsJsNode, \
 from utils import TestCase, TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='UA-123456-7',
                    GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_SINGLE_DOMAIN)
@@ -21,44 +23,45 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('google_analytics_js', 'google_analytics_js')
-        self.assertTrue("""(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        assert """(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r, r)
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
-        self.assertTrue("ga('send', 'pageview');" in r, r)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r
+        assert "ga('create', 'UA-123456-7', 'auto', {});" in r
+        assert "ga('send', 'pageview');" in r
 
     def test_node(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        assert """(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r, r)
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
-        self.assertTrue("ga('send', 'pageview');" in r, r)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r
+        assert "ga('create', 'UA-123456-7', 'auto', {});" in r
+        assert "ga('send', 'pageview');" in r
 
     @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID=None)
     def test_no_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode()
 
     @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='wrong')
     def test_wrong_property_id(self):
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode()
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_SUBDOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_subdomains(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue(
-            """ga('create', 'UA-123456-7', 'auto', {"legacyCookieDomain": "example.com"}""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"legacyCookieDomain": "example.com"}""" in r
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_domains(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {" in r, r)
-        self.assertTrue('"legacyCookieDomain": "example.com"' in r, r)
-        self.assertTrue('"allowLinker\": true' in r, r)
+        assert "ga('create', 'UA-123456-7', 'auto', {" in r
+        assert '"legacyCookieDomain": "example.com"' in r
+        assert '"allowLinker\": true' in r
 
     def test_custom_vars(self):
         context = Context({
@@ -68,17 +71,17 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             'google_analytics_var5': ('test5', 2.2),
         })
         r = GoogleAnalyticsJsNode().render(context)
-        self.assertTrue("ga('set', 'test1', 'foo');" in r, r)
-        self.assertTrue("ga('set', 'test2', 'bar');" in r, r)
-        self.assertTrue("ga('set', 'test4', 1);" in r, r)
-        self.assertTrue("ga('set', 'test5', 2.2);" in r, r)
+        assert "ga('set', 'test1', 'foo');" in r
+        assert "ga('set', 'test2', 'bar');" in r
+        assert "ga('set', 'test4', 1);" in r
+        assert "ga('set', 'test5', 2.2);" in r
 
     def test_display_advertising(self):
         with override_settings(GOOGLE_ANALYTICS_DISPLAY_ADVERTISING=True):
             r = GoogleAnalyticsJsNode().render(Context())
-            self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {});
+            assert """ga('create', 'UA-123456-7', 'auto', {});
 ga('require', 'displayfeatures');
-ga('send', 'pageview');""" in r, r)
+ga('send', 'pageview');""" in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -86,77 +89,79 @@ ga('send', 'pageview');""" in r, r)
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = GoogleAnalyticsJsNode().render(context)
-        self.assertTrue(r.startswith(
-            '<!-- Google Analytics disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith(
+            '<!-- Google Analytics disabled on internal IP address')
+        assert r.endswith('-->')
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=True)
     def test_anonymize_ip(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('set', 'anonymizeIp', true);" in r, r)
+        assert "ga('set', 'anonymizeIp', true);" in r
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=False)
     def test_anonymize_ip_not_present(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertFalse("ga('set', 'anonymizeIp', true);" in r, r)
+        assert "ga('set', 'anonymizeIp', true);" not in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=0.0)
     def test_set_sample_rate_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"sampleRate": 0});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"sampleRate": 0});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE='100.00')
     def test_set_sample_rate_max(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"sampleRate": 100});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"sampleRate": 100});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=-1)
     def test_exception_whenset_sample_rate_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=101)
     def test_exception_when_set_sample_rate_too_large(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
     def test_set_site_speed_sample_rate_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue(
-            """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 0});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 0});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
     def test_set_site_speed_sample_rate_max(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue(
-            """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 100});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 100});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
     def test_exception_whenset_site_speed_sample_rate_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=101)
     def test_exception_when_set_site_speed_sample_rate_too_large(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=0)
     def test_set_cookie_expiration_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 0});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 0});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION='10000')
     def test_set_cookie_expiration_as_string(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue(
-            """ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 10000});""" in r, r)
+        assert """ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 10000});""" in r
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=-1)
     def test_exception_when_set_cookie_expiration_too_small(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)
 
 
 @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='UA-123456-7',
@@ -166,4 +171,5 @@ ga('send', 'pageview');""" in r, r)
 class NoDomainTestCase(TestCase):
     def test_exception_without_domain(self):
         context = Context()
-        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+        with pytest.raises(AnalyticalException):
+            GoogleAnalyticsJsNode().render(context)

--- a/tests/unit/test_tag_gosquared.py
+++ b/tests/unit/test_tag_gosquared.py
@@ -11,6 +11,8 @@ from analytical.templatetags.gosquared import GoSquaredNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(GOSQUARED_SITE_TOKEN='ABC-123456-D')
 class GoSquaredTagTestCase(TagTestCase):
@@ -20,26 +22,28 @@ class GoSquaredTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('gosquared', 'gosquared')
-        self.assertTrue('GoSquared.acct = "ABC-123456-D";' in r, r)
+        assert 'GoSquared.acct = "ABC-123456-D";' in r
 
     def test_node(self):
         r = GoSquaredNode().render(Context({}))
-        self.assertTrue('GoSquared.acct = "ABC-123456-D";' in r, r)
+        assert 'GoSquared.acct = "ABC-123456-D";' in r
 
     @override_settings(GOSQUARED_SITE_TOKEN=None)
     def test_no_token(self):
-        self.assertRaises(AnalyticalException, GoSquaredNode)
+        with pytest.raises(AnalyticalException):
+            GoSquaredNode()
 
     @override_settings(GOSQUARED_SITE_TOKEN='this is not a token')
     def test_wrong_token(self):
-        self.assertRaises(AnalyticalException, GoSquaredNode)
+        with pytest.raises(AnalyticalException):
+            GoSquaredNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_auto_identify(self):
         r = GoSquaredNode().render(Context({
             'user': User(username='test', first_name='Test', last_name='User'),
         }))
-        self.assertTrue('GoSquared.UserName = "Test User";' in r, r)
+        assert 'GoSquared.UserName = "Test User";' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_manual_identify(self):
@@ -47,12 +51,12 @@ class GoSquaredTagTestCase(TagTestCase):
             'user': User(username='test', first_name='Test', last_name='User'),
             'gosquared_identity': 'test_identity',
         }))
-        self.assertTrue('GoSquared.UserName = "test_identity";' in r, r)
+        assert 'GoSquared.UserName = "test_identity";' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = GoSquaredNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse('GoSquared.UserName = ' in r, r)
+        assert 'GoSquared.UserName = ' not in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -60,6 +64,5 @@ class GoSquaredTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = GoSquaredNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- GoSquared disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- GoSquared disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_hubspot.py
+++ b/tests/unit/test_tag_hubspot.py
@@ -10,6 +10,8 @@ from analytical.templatetags.hubspot import HubSpotNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(HUBSPOT_PORTAL_ID='1234')
 class HubSpotTagTestCase(TagTestCase):
@@ -19,21 +21,27 @@ class HubSpotTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('hubspot', 'hubspot')
-        self.assertTrue("n.id=i;n.src='//js.hs-analytics.net/analytics/'"
-                        "+(Math.ceil(new Date()/r)*r)+'/1234.js';" in r, r)
+        assert (
+            "n.id=i;n.src='//js.hs-analytics.net/analytics/'"
+            "+(Math.ceil(new Date()/r)*r)+'/1234.js';"
+        ) in r
 
     def test_node(self):
         r = HubSpotNode().render(Context())
-        self.assertTrue("n.id=i;n.src='//js.hs-analytics.net/analytics/'"
-                        "+(Math.ceil(new Date()/r)*r)+'/1234.js';" in r, r)
+        assert (
+            "n.id=i;n.src='//js.hs-analytics.net/analytics/'"
+            "+(Math.ceil(new Date()/r)*r)+'/1234.js';"
+        ) in r
 
     @override_settings(HUBSPOT_PORTAL_ID=None)
     def test_no_portal_id(self):
-        self.assertRaises(AnalyticalException, HubSpotNode)
+        with pytest.raises(AnalyticalException):
+            HubSpotNode()
 
     @override_settings(HUBSPOT_PORTAL_ID='wrong')
     def test_wrong_portal_id(self):
-        self.assertRaises(AnalyticalException, HubSpotNode)
+        with pytest.raises(AnalyticalException):
+            HubSpotNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -41,5 +49,5 @@ class HubSpotTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = HubSpotNode().render(context)
-        self.assertTrue(r.startswith('<!-- HubSpot disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- HubSpot disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_intercom.py
+++ b/tests/unit/test_tag_intercom.py
@@ -13,6 +13,8 @@ from analytical.templatetags.intercom import IntercomNode, intercom_user_hash
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(INTERCOM_APP_ID="abc123xyz")
 class IntercomTagTestCase(TagTestCase):
@@ -22,7 +24,7 @@ class IntercomTagTestCase(TagTestCase):
 
     def test_tag(self):
         rendered_tag = self.render_tag('intercom', 'intercom')
-        self.assertTrue(rendered_tag.strip().startswith('<script id="IntercomSettingsScriptTag">'))
+        assert rendered_tag.strip().startswith('<script id="IntercomSettingsScriptTag">')
 
     def test_node(self):
         now = datetime.datetime(2014, 4, 9, 15, 15, 0)
@@ -35,20 +37,22 @@ class IntercomTagTestCase(TagTestCase):
         )
         rendered_tag = IntercomNode().render(Context({'user': user}))
         # Because the json isn't predictably ordered, we can't just test the whole thing verbatim.
-        self.assertEqual("""
+        assert rendered_tag == """
 <script id="IntercomSettingsScriptTag">
   window.intercomSettings = {"app_id": "abc123xyz", "created_at": 1397074500, "email": "test@example.com", "name": "Firstname Lastname", "user_id": %(user_id)s};
 </script>
 <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://static.intercomcdn.com/intercom.v1.js';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
-""" % {'user_id': user.pk}, rendered_tag)  # noqa
+""" % {'user_id': user.pk}  # noqa
 
     @override_settings(INTERCOM_APP_ID=None)
     def test_no_account_number(self):
-        self.assertRaises(AnalyticalException, IntercomNode)
+        with pytest.raises(AnalyticalException):
+            IntercomNode()
 
     @override_settings(INTERCOM_APP_ID='123abQ')
     def test_wrong_account_number(self):
-        self.assertRaises(AnalyticalException, IntercomNode)
+        with pytest.raises(AnalyticalException):
+            IntercomNode()
 
     def test_identify_name_email_and_created_at(self):
         now = datetime.datetime(2014, 4, 9, 15, 15, 0)
@@ -62,18 +66,17 @@ class IntercomTagTestCase(TagTestCase):
         r = IntercomNode().render(Context({
             'user': user,
         }))
-        self.assertTrue('window.intercomSettings = {'
-                        '"app_id": "abc123xyz", "created_at": 1397074500, '
-                        '"email": "test@example.com", "name": "Firstname Lastname", '
-                        '"user_id": %(user_id)s'
-                        '};' % {'user_id': user.pk} in r, msg=r)
+        assert (
+            'window.intercomSettings = {"app_id": "abc123xyz", "created_at": 1397074500, '
+            f'"email": "test@example.com", "name": "Firstname Lastname", "user_id": {user.pk}}};'
+        ) in r
 
     def test_custom(self):
         r = IntercomNode().render(Context({
                 'intercom_var1': 'val1',
                 'intercom_var2': 'val2'
         }))
-        self.assertTrue('var1": "val1", "var2": "val2"' in r)
+        assert 'var1": "val1", "var2": "val2"' in r
 
     def test_identify_name_and_email(self):
         r = IntercomNode().render(Context({
@@ -83,25 +86,25 @@ class IntercomTagTestCase(TagTestCase):
                     last_name='Lastname',
                     email="test@example.com"),
         }))
-        self.assertTrue('"email": "test@example.com", "name": "Firstname Lastname"' in r)
+        assert '"email": "test@example.com", "name": "Firstname Lastname"' in r
 
     def test_identify_username_no_email(self):
         r = IntercomNode().render(Context({'user': User(username='test')}))
-        self.assertTrue('"name": "test"' in r, r)
+        assert '"name": "test"' in r, r
 
     def test_no_identify_when_explicit_name(self):
         r = IntercomNode().render(Context({
             'intercom_name': 'explicit',
             'user': User(username='implicit'),
         }))
-        self.assertTrue('"name": "explicit"' in r, r)
+        assert '"name": "explicit"' in r, r
 
     def test_no_identify_when_explicit_email(self):
         r = IntercomNode().render(Context({
             'intercom_email': 'explicit',
             'user': User(username='implicit'),
         }))
-        self.assertTrue('"email": "explicit"' in r, r)
+        assert '"email": "explicit"' in r, r
 
     @override_settings(INTERCOM_HMAC_SECRET_KEY='secret')
     def test_user_hash__without_user_details(self):
@@ -109,9 +112,7 @@ class IntercomTagTestCase(TagTestCase):
         No `user_hash` without `user_id` or `email`.
         """
         attrs = IntercomNode()._get_custom_attrs(Context())
-        self.assertEqual({
-            'created_at': None,
-        }, attrs)
+        assert {'created_at': None} == attrs
 
     @override_settings(INTERCOM_HMAC_SECRET_KEY='secret')
     def test_user_hash__with_user(self):
@@ -122,13 +123,13 @@ class IntercomTagTestCase(TagTestCase):
             email='test@example.com',
         )  # type: User
         attrs = IntercomNode()._get_custom_attrs(Context({'user': user}))
-        self.assertEqual({
+        assert attrs == {
             'created_at': int(user.date_joined.timestamp()),
             'email': 'test@example.com',
             'name': '',
             'user_hash': intercom_user_hash(str(user.pk)),
             'user_id': user.pk,
-        }, attrs)
+        }
 
     @override_settings(INTERCOM_HMAC_SECRET_KEY='secret')
     def test_user_hash__with_explicit_user_id(self):
@@ -139,13 +140,13 @@ class IntercomTagTestCase(TagTestCase):
             'intercom_email': 'test@example.com',
             'intercom_user_id': '5',
         }))
-        self.assertEqual({
+        assert attrs == {
             'created_at': None,
             'email': 'test@example.com',
             # HMAC for user_id:
             'user_hash': 'd3123a7052b42272d9b520235008c248a5aff3221cc0c530b754702ad91ab102',
             'user_id': '5',
-        }, attrs)
+        }
 
     @override_settings(INTERCOM_HMAC_SECRET_KEY='secret')
     def test_user_hash__with_explicit_email(self):
@@ -155,12 +156,12 @@ class IntercomTagTestCase(TagTestCase):
         attrs = IntercomNode()._get_custom_attrs(Context({
             'intercom_email': 'test@example.com',
         }))
-        self.assertEqual({
+        assert attrs == {
             'created_at': None,
             'email': 'test@example.com',
             # HMAC for email:
             'user_hash': '49e43229ee99dca2565241719b8341b04e71dd4de0628f991b5bea30a526e153',
-        }, attrs)
+        }
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -168,5 +169,5 @@ class IntercomTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = IntercomNode().render(context)
-        self.assertTrue(r.startswith('<!-- Intercom disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Intercom disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_kiss_insights.py
+++ b/tests/unit/test_tag_kiss_insights.py
@@ -10,6 +10,8 @@ from analytical.templatetags.kiss_insights import KissInsightsNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(KISS_INSIGHTS_ACCOUNT_NUMBER='12345', KISS_INSIGHTS_SITE_CODE='abc')
 class KissInsightsTagTestCase(TagTestCase):
@@ -19,38 +21,42 @@ class KissInsightsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('kiss_insights', 'kiss_insights')
-        self.assertTrue("//s3.amazonaws.com/ki.js/12345/abc.js" in r, r)
+        assert "//s3.amazonaws.com/ki.js/12345/abc.js" in r
 
     def test_node(self):
         r = KissInsightsNode().render(Context())
-        self.assertTrue("//s3.amazonaws.com/ki.js/12345/abc.js" in r, r)
+        assert "//s3.amazonaws.com/ki.js/12345/abc.js" in r
 
     @override_settings(KISS_INSIGHTS_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
-        self.assertRaises(AnalyticalException, KissInsightsNode)
+        with pytest.raises(AnalyticalException):
+            KissInsightsNode()
 
     @override_settings(KISS_INSIGHTS_SITE_CODE=None)
     def test_no_site_code(self):
-        self.assertRaises(AnalyticalException, KissInsightsNode)
+        with pytest.raises(AnalyticalException):
+            KissInsightsNode()
 
     @override_settings(KISS_INSIGHTS_ACCOUNT_NUMBER='abcde')
     def test_wrong_account_number(self):
-        self.assertRaises(AnalyticalException, KissInsightsNode)
+        with pytest.raises(AnalyticalException):
+            KissInsightsNode()
 
     @override_settings(KISS_INSIGHTS_SITE_CODE='abc def')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, KissInsightsNode)
+        with pytest.raises(AnalyticalException):
+            KissInsightsNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = KissInsightsNode().render(Context({'user': User(username='test')}))
-        self.assertTrue("_kiq.push(['identify', 'test']);" in r, r)
+        assert "_kiq.push(['identify', 'test']);" in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = KissInsightsNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse("_kiq.push(['identify', " in r, r)
+        assert "_kiq.push(['identify', " not in r
 
     def test_show_survey(self):
         r = KissInsightsNode().render(Context({'kiss_insights_show_survey': 1234}))
-        self.assertTrue("_kiq.push(['showSurvey', 1234]);" in r, r)
+        assert "_kiq.push(['showSurvey', 1234]);" in r

--- a/tests/unit/test_tag_kiss_metrics.py
+++ b/tests/unit/test_tag_kiss_metrics.py
@@ -11,6 +11,8 @@ from analytical.templatetags.kiss_metrics import KissMetricsNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(KISS_METRICS_API_KEY='0123456789abcdef0123456789abcdef01234567')
 class KissMetricsTagTestCase(TagTestCase):
@@ -20,55 +22,55 @@ class KissMetricsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('kiss_metrics', 'kiss_metrics')
-        self.assertTrue("//doug1izaerwt3.cloudfront.net/"
-                        "0123456789abcdef0123456789abcdef01234567.1.js" in r, r)
+        assert "//doug1izaerwt3.cloudfront.net/0123456789abcdef0123456789abcdef01234567.1.js" in r
 
     def test_node(self):
         r = KissMetricsNode().render(Context())
-        self.assertTrue("//doug1izaerwt3.cloudfront.net/"
-                        "0123456789abcdef0123456789abcdef01234567.1.js" in r, r)
+        assert "//doug1izaerwt3.cloudfront.net/0123456789abcdef0123456789abcdef01234567.1.js" in r
 
     @override_settings(KISS_METRICS_API_KEY=None)
     def test_no_api_key(self):
-        self.assertRaises(AnalyticalException, KissMetricsNode)
+        with pytest.raises(AnalyticalException):
+            KissMetricsNode()
 
     @override_settings(KISS_METRICS_API_KEY='0123456789abcdef0123456789abcdef0123456')
     def test_api_key_too_short(self):
-        self.assertRaises(AnalyticalException, KissMetricsNode)
+        with pytest.raises(AnalyticalException):
+            KissMetricsNode()
 
     @override_settings(KISS_METRICS_API_KEY='0123456789abcdef0123456789abcdef012345678')
     def test_api_key_too_long(self):
-        self.assertRaises(AnalyticalException, KissMetricsNode)
+        with pytest.raises(AnalyticalException):
+            KissMetricsNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = KissMetricsNode().render(Context({'user': User(username='test')}))
-        self.assertTrue("_kmq.push(['identify', 'test']);" in r, r)
+        assert "_kmq.push(['identify', 'test']);" in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = KissMetricsNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse("_kmq.push(['identify', " in r, r)
+        assert "_kmq.push(['identify', " not in r
 
     def test_event(self):
         r = KissMetricsNode().render(Context({
             'kiss_metrics_event': ('test_event', {'prop1': 'val1', 'prop2': 'val2'}),
         }))
-        self.assertTrue("_kmq.push(['record', 'test_event', "
-                        '{"prop1": "val1", "prop2": "val2"}]);' in r, r)
+        assert "_kmq.push(['record', 'test_event', "
+        '{"prop1": "val1", "prop2": "val2"}]);' in r
 
     def test_property(self):
         r = KissMetricsNode().render(Context({
             'kiss_metrics_properties': {'prop1': 'val1', 'prop2': 'val2'},
         }))
-        self.assertTrue("_kmq.push([\'set\', "
-                        '{"prop1": "val1", "prop2": "val2"}]);' in r, r)
+        assert '_kmq.push([\'set\', {"prop1": "val1", "prop2": "val2"}]);' in r
 
     def test_alias(self):
         r = KissMetricsNode().render(Context({
             'kiss_metrics_alias': {'test': 'test_alias'},
         }))
-        self.assertTrue("_kmq.push(['alias', 'test', 'test_alias']);" in r, r)
+        assert "_kmq.push(['alias', 'test', 'test_alias']);" in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -76,6 +78,5 @@ class KissMetricsTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = KissMetricsNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- KISSmetrics disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- KISSmetrics disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_luckyorange.py
+++ b/tests/unit/test_tag_luckyorange.py
@@ -10,6 +10,7 @@ from analytical.templatetags.luckyorange import LuckyOrangeNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
 
 expected_html = """\
 <script type='text/javascript'>
@@ -30,30 +31,27 @@ class LuckyOrangeTagTestCase(TagTestCase):
 
     def test_tag(self):
         html = self.render_tag('luckyorange', 'luckyorange')
-        self.assertEqual(expected_html, html)
+        assert expected_html == html
 
     def test_node(self):
         html = LuckyOrangeNode().render(Context({}))
-        self.assertEqual(expected_html, html)
+        assert expected_html == html
 
     def test_tags_take_no_args(self):
-        self.assertRaisesRegex(
-            TemplateSyntaxError,
-            r"^'luckyorange' takes no arguments$",
-            lambda: (Template('{% load luckyorange %}{% luckyorange "arg" %}')
-                     .render(Context({}))),
-        )
+        with pytest.raises(TemplateSyntaxError, match="'luckyorange' takes no arguments"):
+            Template('{% load luckyorange %}{% luckyorange "arg" %}').render(Context({}))
 
     @override_settings(LUCKYORANGE_SITE_ID=None)
     def test_no_id(self):
-        expected_pattern = r'^LUCKYORANGE_SITE_ID setting is not set$'
-        self.assertRaisesRegex(AnalyticalException, expected_pattern, LuckyOrangeNode)
+        with pytest.raises(AnalyticalException, match="LUCKYORANGE_SITE_ID setting is not set"):
+            LuckyOrangeNode()
 
     @override_settings(LUCKYORANGE_SITE_ID='invalid')
     def test_invalid_id(self):
         expected_pattern = (
             r"^LUCKYORANGE_SITE_ID setting: must be \(a string containing\) a number: 'invalid'$")
-        self.assertRaisesRegex(AnalyticalException, expected_pattern, LuckyOrangeNode)
+        with pytest.raises(AnalyticalException, match=expected_pattern):
+            LuckyOrangeNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -67,16 +65,16 @@ class LuckyOrangeTagTestCase(TagTestCase):
                 expected_html,
                 '-->',
             ])
-        self.assertEqual(disabled_html, actual_html)
+        assert disabled_html == actual_html
 
     def test_contribute_to_analytical(self):
         """
         `luckyorange.contribute_to_analytical` registers the head and body nodes.
         """
         template_nodes = _load_template_nodes()
-        self.assertEqual({
+        assert template_nodes == {
             'head_top': [],
             'head_bottom': [LuckyOrangeNode],
             'body_top': [],
             'body_bottom': [],
-        }, template_nodes)
+        }

--- a/tests/unit/test_tag_matomo.py
+++ b/tests/unit/test_tag_matomo.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.template import Context
 from django.test.utils import override_settings
+import pytest
 
 from analytical.templatetags.matomo import MatomoNode
 from utils import TagTestCase
@@ -20,71 +21,78 @@ class MatomoTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('matomo', 'matomo')
-        self.assertTrue('"//example.com/"' in r, r)
-        self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
-                        in r, r)
+        assert '"//example.com/"' in r
+        assert "_paq.push(['setSiteId', 345]);" in r
+        assert 'img src="//example.com/piwik.php?idsite=345"' in r
 
     def test_node(self):
         r = MatomoNode().render(Context({}))
-        self.assertTrue('"//example.com/";' in r, r)
-        self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
-                        in r, r)
+        assert '"//example.com/";' in r
+        assert "_paq.push(['setSiteId', 345]);" in r
+        assert 'img src="//example.com/piwik.php?idsite=345"' in r
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com/matomo',
                        MATOMO_SITE_ID='345')
     def test_domain_path_valid(self):
         r = self.render_tag('matomo', 'matomo')
-        self.assertTrue('"//example.com/matomo/"' in r, r)
+        assert '"//example.com/matomo/"' in r
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:1234',
                        MATOMO_SITE_ID='345')
     def test_domain_port_valid(self):
         r = self.render_tag('matomo', 'matomo')
-        self.assertTrue('"//example.com:1234/";' in r, r)
+        assert '"//example.com:1234/";' in r
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:1234/matomo',
                        MATOMO_SITE_ID='345')
     def test_domain_port_path_valid(self):
         r = self.render_tag('matomo', 'matomo')
-        self.assertTrue('"//example.com:1234/matomo/"' in r, r)
+        assert '"//example.com:1234/matomo/"' in r
 
     @override_settings(MATOMO_DOMAIN_PATH=None)
     def test_no_domain(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_SITE_ID=None)
     def test_no_siteid(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_SITE_ID='x')
     def test_siteid_not_a_number(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='http://www.example.com')
     def test_domain_protocol_invalid(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com/')
     def test_domain_slash_invalid(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:123:456')
     def test_domain_multi_port(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:')
     def test_domain_incomplete_port(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:/matomo')
     def test_domain_uri_incomplete_port(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(MATOMO_DOMAIN_PATH='example.com:12df')
     def test_domain_port_invalid(self):
-        self.assertRaises(AnalyticalException, MatomoNode)
+        with pytest.raises(AnalyticalException):
+            MatomoNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -92,20 +100,18 @@ class MatomoTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = MatomoNode().render(context)
-        self.assertTrue(r.startswith(
-            '<!-- Matomo disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Matomo disabled on internal IP address')
+        assert r.endswith('-->')
 
     def test_uservars(self):
         context = Context({'matomo_vars': [(1, 'foo', 'foo_val'),
                                            (2, 'bar', 'bar_val', 'page'),
                                            (3, 'spam', 'spam_val', 'visit')]})
         r = MatomoNode().render(context)
-        msg = 'Incorrect Matomo custom variable rendering. Expected:\n%s\nIn:\n%s'
         for var_code in ['_paq.push(["setCustomVariable", 1, "foo", "foo_val", "page"]);',
                          '_paq.push(["setCustomVariable", 2, "bar", "bar_val", "page"]);',
                          '_paq.push(["setCustomVariable", 3, "spam", "spam_val", "visit"]);']:
-            self.assertIn(var_code, r, msg % (var_code, r))
+            assert var_code in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_default_usertrack(self):
@@ -113,27 +119,24 @@ class MatomoTagTestCase(TagTestCase):
             'user': User(username='BDFL', first_name='Guido', last_name='van Rossum')
         })
         r = MatomoNode().render(context)
-        msg = 'Incorrect Matomo user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     def test_matomo_usertrack(self):
         context = Context({
             'matomo_identity': 'BDFL'
         })
         r = MatomoNode().render(context)
-        msg = 'Incorrect Matomo user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     def test_analytical_usertrack(self):
         context = Context({
             'analytical_identity': 'BDFL'
         })
         r = MatomoNode().render(context)
-        msg = 'Incorrect Matomo user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_disable_usertrack(self):
@@ -142,11 +145,10 @@ class MatomoTagTestCase(TagTestCase):
             'matomo_identity': None
         })
         r = MatomoNode().render(context)
-        msg = 'Incorrect Matomo user tracking rendering.\nFound:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertNotIn(var_code, r, msg % (var_code, r))
+        assert var_code not in r
 
     @override_settings(MATOMO_DISABLE_COOKIES=True)
     def test_disable_cookies(self):
         r = MatomoNode().render(Context({}))
-        self.assertTrue("_paq.push(['disableCookies']);" in r, r)
+        assert "_paq.push(['disableCookies']);" in r

--- a/tests/unit/test_tag_mixpanel.py
+++ b/tests/unit/test_tag_mixpanel.py
@@ -11,6 +11,8 @@ from analytical.templatetags.mixpanel import MixpanelNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(MIXPANEL_API_TOKEN='0123456789abcdef0123456789abcdef')
 class MixpanelTagTestCase(TagTestCase):
@@ -20,40 +22,43 @@ class MixpanelTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('mixpanel', 'mixpanel')
-        self.assertIn("mixpanel.init('0123456789abcdef0123456789abcdef');", r)
+        assert "mixpanel.init('0123456789abcdef0123456789abcdef');" in r
 
     def test_node(self):
         r = MixpanelNode().render(Context())
-        self.assertIn("mixpanel.init('0123456789abcdef0123456789abcdef');", r)
+        assert "mixpanel.init('0123456789abcdef0123456789abcdef');" in r
 
     @override_settings(MIXPANEL_API_TOKEN=None)
     def test_no_token(self):
-        self.assertRaises(AnalyticalException, MixpanelNode)
+        with pytest.raises(AnalyticalException):
+            MixpanelNode()
 
     @override_settings(MIXPANEL_API_TOKEN='0123456789abcdef0123456789abcdef0')
     def test_token_too_long(self):
-        self.assertRaises(AnalyticalException, MixpanelNode)
+        with pytest.raises(AnalyticalException):
+            MixpanelNode()
 
     @override_settings(MIXPANEL_API_TOKEN='0123456789abcdef0123456789abcde')
     def test_token_too_short(self):
-        self.assertRaises(AnalyticalException, MixpanelNode)
+        with pytest.raises(AnalyticalException):
+            MixpanelNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = MixpanelNode().render(Context({'user': User(username='test')}))
-        self.assertIn("mixpanel.identify('test');", r)
+        assert "mixpanel.identify('test');" in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = MixpanelNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse("mixpanel.register_once({distinct_id:" in r, r)
+        assert "mixpanel.register_once({distinct_id:" not in r
 
     def test_event(self):
         r = MixpanelNode().render(Context({
             'mixpanel_event': ('test_event', {'prop1': 'val1', 'prop2': 'val2'}),
         }))
-        self.assertTrue("mixpanel.track('test_event', "
-                        '{"prop1": "val1", "prop2": "val2"});' in r, r)
+        assert "mixpanel.track('test_event', "
+        '{"prop1": "val1", "prop2": "val2"});' in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -61,6 +66,5 @@ class MixpanelTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = MixpanelNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Mixpanel disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Mixpanel disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_optimizely.py
+++ b/tests/unit/test_tag_optimizely.py
@@ -10,6 +10,8 @@ from analytical.templatetags.optimizely import OptimizelyNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(OPTIMIZELY_ACCOUNT_NUMBER='1234567')
 class OptimizelyTagTestCase(TagTestCase):
@@ -18,22 +20,22 @@ class OptimizelyTagTestCase(TagTestCase):
     """
 
     def test_tag(self):
-        self.assertEqual(
-                '<script src="//cdn.optimizely.com/js/1234567.js"></script>',
-                self.render_tag('optimizely', 'optimizely'))
+        expected = '<script src="//cdn.optimizely.com/js/1234567.js"></script>'
+        assert self.render_tag('optimizely', 'optimizely') == expected
 
     def test_node(self):
-        self.assertEqual(
-                '<script src="//cdn.optimizely.com/js/1234567.js"></script>',
-                OptimizelyNode().render(Context()))
+        expected = '<script src="//cdn.optimizely.com/js/1234567.js"></script>'
+        assert OptimizelyNode().render(Context()) == expected
 
     @override_settings(OPTIMIZELY_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
-        self.assertRaises(AnalyticalException, OptimizelyNode)
+        with pytest.raises(AnalyticalException):
+            OptimizelyNode()
 
     @override_settings(OPTIMIZELY_ACCOUNT_NUMBER='123abc')
     def test_wrong_account_number(self):
-        self.assertRaises(AnalyticalException, OptimizelyNode)
+        with pytest.raises(AnalyticalException):
+            OptimizelyNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -41,6 +43,5 @@ class OptimizelyTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = OptimizelyNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Optimizely disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Optimizely disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_performable.py
+++ b/tests/unit/test_tag_performable.py
@@ -11,6 +11,8 @@ from analytical.templatetags.performable import PerformableNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(PERFORMABLE_API_KEY='123ABC')
 class PerformableTagTestCase(TagTestCase):
@@ -20,19 +22,21 @@ class PerformableTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('performable', 'performable')
-        self.assertTrue('/performable/pax/123ABC.js' in r, r)
+        assert '/performable/pax/123ABC.js' in r
 
     def test_node(self):
         r = PerformableNode().render(Context())
-        self.assertTrue('/performable/pax/123ABC.js' in r, r)
+        assert '/performable/pax/123ABC.js' in r
 
     @override_settings(PERFORMABLE_API_KEY=None)
     def test_no_api_key(self):
-        self.assertRaises(AnalyticalException, PerformableNode)
+        with pytest.raises(AnalyticalException):
+            PerformableNode()
 
     @override_settings(PERFORMABLE_API_KEY='123 ABC')
     def test_wrong_account_number(self):
-        self.assertRaises(AnalyticalException, PerformableNode)
+        with pytest.raises(AnalyticalException):
+            PerformableNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -40,19 +44,18 @@ class PerformableTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = PerformableNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Performable disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Performable disabled on internal IP address')
+        assert r.endswith('-->')
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = PerformableNode().render(Context({'user': User(username='test')}))
-        self.assertTrue('_paq.push(["identify", {identity: "test"}]);' in r, r)
+        assert '_paq.push(["identify", {identity: "test"}]);' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = PerformableNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse('_paq.push(["identify", ' in r, r)
+        assert '_paq.push(["identify", ' not in r
 
 
 class PerformableEmbedTagTestCase(TagTestCase):
@@ -63,9 +66,5 @@ class PerformableEmbedTagTestCase(TagTestCase):
     def test_tag(self):
         domain = 'example.com'
         page = 'test'
-        tag = self.render_tag(
-            'performable', 'performable_embed "%s" "%s"' % (domain, page)
-        )
-        self.assertIn(
-            "$f.initialize({'host': 'example.com', 'page': 'test'});", tag
-        )
+        tag = self.render_tag('performable', f'performable_embed "{domain}" "{page}"')
+        assert "$f.initialize({'host': 'example.com', 'page': 'test'});" in tag

--- a/tests/unit/test_tag_piwik.py
+++ b/tests/unit/test_tag_piwik.py
@@ -11,6 +11,8 @@ from analytical.templatetags.piwik import PiwikNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(PIWIK_DOMAIN_PATH='example.com', PIWIK_SITE_ID='345')
 class PiwikTagTestCase(TagTestCase):
@@ -20,71 +22,78 @@ class PiwikTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com/"' in r, r)
-        self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
-                        in r, r)
+        assert '"//example.com/"' in r
+        assert "_paq.push(['setSiteId', 345]);" in r
+        assert 'img src="//example.com/piwik.php?idsite=345"' in r
 
     def test_node(self):
         r = PiwikNode().render(Context({}))
-        self.assertTrue('"//example.com/";' in r, r)
-        self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
-                        in r, r)
+        assert '"//example.com/";' in r
+        assert "_paq.push(['setSiteId', 345]);" in r
+        assert 'img src="//example.com/piwik.php?idsite=345"' in r
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com/piwik',
                        PIWIK_SITE_ID='345')
     def test_domain_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com/piwik/"' in r, r)
+        assert '"//example.com/piwik/"' in r
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234',
                        PIWIK_SITE_ID='345')
     def test_domain_port_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com:1234/";' in r, r)
+        assert '"//example.com:1234/";' in r
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234/piwik',
                        PIWIK_SITE_ID='345')
     def test_domain_port_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com:1234/piwik/"' in r, r)
+        assert '"//example.com:1234/piwik/"' in r
 
     @override_settings(PIWIK_DOMAIN_PATH=None)
     def test_no_domain(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_SITE_ID=None)
     def test_no_siteid(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_SITE_ID='x')
     def test_siteid_not_a_number(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='http://www.example.com')
     def test_domain_protocol_invalid(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com/')
     def test_domain_slash_invalid(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:123:456')
     def test_domain_multi_port(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:')
     def test_domain_incomplete_port(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:/piwik')
     def test_domain_uri_incomplete_port(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:12df')
     def test_domain_port_invalid(self):
-        self.assertRaises(AnalyticalException, PiwikNode)
+        with pytest.raises(AnalyticalException):
+            PiwikNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -92,20 +101,18 @@ class PiwikTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = PiwikNode().render(context)
-        self.assertTrue(r.startswith(
-            '<!-- Piwik disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Piwik disabled on internal IP address')
+        assert r.endswith('-->')
 
     def test_uservars(self):
         context = Context({'piwik_vars': [(1, 'foo', 'foo_val'),
                                           (2, 'bar', 'bar_val', 'page'),
                                           (3, 'spam', 'spam_val', 'visit')]})
         r = PiwikNode().render(context)
-        msg = 'Incorrect Piwik custom variable rendering. Expected:\n%s\nIn:\n%s'
         for var_code in ['_paq.push(["setCustomVariable", 1, "foo", "foo_val", "page"]);',
                          '_paq.push(["setCustomVariable", 2, "bar", "bar_val", "page"]);',
                          '_paq.push(["setCustomVariable", 3, "spam", "spam_val", "visit"]);']:
-            self.assertIn(var_code, r, msg % (var_code, r))
+            assert var_code in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_default_usertrack(self):
@@ -113,27 +120,24 @@ class PiwikTagTestCase(TagTestCase):
             'user': User(username='BDFL', first_name='Guido', last_name='van Rossum')
         })
         r = PiwikNode().render(context)
-        msg = 'Incorrect Piwik user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     def test_piwik_usertrack(self):
         context = Context({
             'piwik_identity': 'BDFL'
         })
         r = PiwikNode().render(context)
-        msg = 'Incorrect Piwik user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     def test_analytical_usertrack(self):
         context = Context({
             'analytical_identity': 'BDFL'
         })
         r = PiwikNode().render(context)
-        msg = 'Incorrect Piwik user tracking rendering.\nNot found:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertIn(var_code, r, msg % (var_code, r))
+        assert var_code in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_disable_usertrack(self):
@@ -142,11 +146,10 @@ class PiwikTagTestCase(TagTestCase):
             'piwik_identity': None
         })
         r = PiwikNode().render(context)
-        msg = 'Incorrect Piwik user tracking rendering.\nFound:\n%s\nIn:\n%s'
         var_code = '_paq.push(["setUserId", "BDFL"]);'
-        self.assertNotIn(var_code, r, msg % (var_code, r))
+        assert var_code not in r
 
     @override_settings(PIWIK_DISABLE_COOKIES=True)
     def test_disable_cookies(self):
         r = PiwikNode().render(Context({}))
-        self.assertTrue("_paq.push(['disableCookies']);" in r, r)
+        assert "_paq.push(['disableCookies']);" in r

--- a/tests/unit/test_tag_rating_mailru.py
+++ b/tests/unit/test_tag_rating_mailru.py
@@ -10,6 +10,8 @@ from analytical.templatetags.rating_mailru import RatingMailruNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(RATING_MAILRU_COUNTER_ID='1234567')
 class RatingMailruTagTestCase(TagTestCase):
@@ -19,19 +21,21 @@ class RatingMailruTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('rating_mailru', 'rating_mailru')
-        self.assertTrue("counter?id=1234567;js=na" in r, r)
+        assert "counter?id=1234567;js=na" in r
 
     def test_node(self):
         r = RatingMailruNode().render(Context({}))
-        self.assertTrue("counter?id=1234567;js=na" in r, r)
+        assert "counter?id=1234567;js=na" in r
 
     @override_settings(RATING_MAILRU_COUNTER_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, RatingMailruNode)
+        with pytest.raises(AnalyticalException):
+            RatingMailruNode()
 
     @override_settings(RATING_MAILRU_COUNTER_ID='1234abc')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, RatingMailruNode)
+        with pytest.raises(AnalyticalException):
+            RatingMailruNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -39,6 +43,5 @@ class RatingMailruTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = RatingMailruNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Rating@Mail.ru disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Rating@Mail.ru disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_snapengage.py
+++ b/tests/unit/test_tag_snapengage.py
@@ -14,6 +14,7 @@ from analytical.templatetags.snapengage import SnapEngageNode, \
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
 
 WIDGET_ID = 'ec329c69-0bf0-4db8-9b77-3f8150fb977e'
 
@@ -31,246 +32,216 @@ class SnapEngageTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('snapengage', 'snapengage')
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-            '"55%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%");' in r
 
     def test_node(self):
         r = SnapEngageNode().render(Context())
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-            '"55%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%");' in r
 
     @override_settings(SNAPENGAGE_WIDGET_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, SnapEngageNode)
+        with pytest.raises(AnalyticalException):
+            SnapEngageNode()
 
     @override_settings(SNAPENGAGE_WIDGET_ID='abc')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, SnapEngageNode)
+        with pytest.raises(AnalyticalException):
+            SnapEngageNode()
 
     def test_no_button(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button': BUTTON_STYLE_NONE,
         }))
-        self.assertTrue('SnapABug.init("ec329c69-0bf0-4db8-9b77-3f8150fb977e")' in r, r)
+        assert 'SnapABug.init("ec329c69-0bf0-4db8-9b77-3f8150fb977e")' in r
         with override_settings(SNAPENGAGE_BUTTON=BUTTON_STYLE_NONE):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.init("ec329c69-0bf0-4db8-9b77-3f8150fb977e")' in r, r)
+            assert 'SnapABug.init("ec329c69-0bf0-4db8-9b77-3f8150fb977e")' in r
 
     def test_live_button(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button': BUTTON_STYLE_LIVE,
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-            '"55%",true);' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%",true);' in r
         with override_settings(SNAPENGAGE_BUTTON=BUTTON_STYLE_LIVE):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-                '"55%",true);' in r, r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%",true);' in r
 
     def test_custom_button(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button': "http://www.example.com/button.png",
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-            '"55%");' in r, r)
-        self.assertTrue(
-            'SnapABug.setButton("http://www.example.com/button.png");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%");' in r
+        assert 'SnapABug.setButton("http://www.example.com/button.png");' in r
         with override_settings(
                 SNAPENGAGE_BUTTON="http://www.example.com/button.png"):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-                '"55%");' in r, r)
-            self.assertTrue(
-                'SnapABug.setButton("http://www.example.com/button.png");' in r,
-                r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","55%");' in r
+            assert 'SnapABug.setButton("http://www.example.com/button.png");' in r
 
     def test_button_location_right(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button_location': BUTTON_LOCATION_RIGHT,
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","1",'
-            '"55%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","1","55%");' in r
         with override_settings(SNAPENGAGE_BUTTON_LOCATION=BUTTON_LOCATION_RIGHT):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","1",'
-                '"55%");' in r, r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","1","55%");' in r
 
     def test_button_location_top(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button_location': BUTTON_LOCATION_TOP,
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","2",'
-            '"55%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","2","55%");' in r
         with override_settings(SNAPENGAGE_BUTTON_LOCATION=BUTTON_LOCATION_TOP):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","2",'
-                '"55%");' in r, r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","2","55%");' in r
 
     def test_button_location_bottom(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button_location': BUTTON_LOCATION_BOTTOM,
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","3",'
-            '"55%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","3","55%");' in r
         with override_settings(
                 SNAPENGAGE_BUTTON_LOCATION=BUTTON_LOCATION_BOTTOM):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","3",'
-                '"55%");' in r, r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","3","55%");' in r
 
     def test_button_offset(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button_location_offset': "30%",
         }))
-        self.assertTrue(
-            'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-            '"30%");' in r, r)
+        assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","30%");' in r
         with override_settings(SNAPENGAGE_BUTTON_LOCATION_OFFSET="30%"):
             r = SnapEngageNode().render(Context())
-            self.assertTrue(
-                'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
-                '"30%");' in r, r)
+            assert 'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0","30%");' in r
 
     def test_button_effect(self):
         r = SnapEngageNode().render(Context({
             'snapengage_button_effect': "-4px",
         }))
-        self.assertTrue('SnapABug.setButtonEffect("-4px");' in r, r)
+        assert 'SnapABug.setButtonEffect("-4px");' in r
         with override_settings(SNAPENGAGE_BUTTON_EFFECT="-4px"):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setButtonEffect("-4px");' in r, r)
+            assert 'SnapABug.setButtonEffect("-4px");' in r
 
     def test_form_position(self):
         r = SnapEngageNode().render(Context({
             'snapengage_form_position': FORM_POSITION_TOP_LEFT,
         }))
-        self.assertTrue('SnapABug.setChatFormPosition("tl");' in r, r)
+        assert 'SnapABug.setChatFormPosition("tl");' in r
         with override_settings(SNAPENGAGE_FORM_POSITION=FORM_POSITION_TOP_LEFT):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setChatFormPosition("tl");' in r, r)
+            assert 'SnapABug.setChatFormPosition("tl");' in r
 
     def test_form_top_position(self):
         r = SnapEngageNode().render(Context({
             'snapengage_form_top_position': 40,
         }))
-        self.assertTrue('SnapABug.setFormTopPosition(40);' in r, r)
+        assert 'SnapABug.setFormTopPosition(40);' in r
         with override_settings(SNAPENGAGE_FORM_TOP_POSITION=40):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setFormTopPosition(40);' in r, r)
+            assert 'SnapABug.setFormTopPosition(40);' in r
 
     def test_domain(self):
         r = SnapEngageNode().render(Context({
             'snapengage_domain': "example.com"}))
-        self.assertTrue('SnapABug.setDomain("example.com");' in r, r)
+        assert 'SnapABug.setDomain("example.com");' in r
         with override_settings(SNAPENGAGE_DOMAIN="example.com"):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setDomain("example.com");' in r, r)
+            assert 'SnapABug.setDomain("example.com");' in r
 
     def test_secure_connection(self):
         r = SnapEngageNode().render(Context({
             'snapengage_secure_connection': True}))
-        self.assertTrue('SnapABug.setSecureConnexion();' in r, r)
+        assert 'SnapABug.setSecureConnexion();' in r
         with override_settings(SNAPENGAGE_SECURE_CONNECTION=True):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setSecureConnexion();' in r, r)
+            assert 'SnapABug.setSecureConnexion();' in r
 
     def test_show_offline(self):
         r = SnapEngageNode().render(Context({
             'snapengage_show_offline': False,
         }))
-        self.assertTrue('SnapABug.allowOffline(false);' in r, r)
+        assert 'SnapABug.allowOffline(false);' in r
         with override_settings(SNAPENGAGE_SHOW_OFFLINE=False):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.allowOffline(false);' in r, r)
+            assert 'SnapABug.allowOffline(false);' in r
 
     def test_proactive_chat(self):
         r = SnapEngageNode().render(Context({
             'snapengage_proactive_chat': False}))
-        self.assertTrue('SnapABug.allowProactiveChat(false);' in r, r)
+        assert 'SnapABug.allowProactiveChat(false);' in r
 
     def test_screenshot(self):
         r = SnapEngageNode().render(Context({
             'snapengage_screenshots': False,
         }))
-        self.assertTrue('SnapABug.allowScreenshot(false);' in r, r)
+        assert 'SnapABug.allowScreenshot(false);' in r
         with override_settings(SNAPENGAGE_SCREENSHOTS=False):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.allowScreenshot(false);' in r, r)
+            assert 'SnapABug.allowScreenshot(false);' in r
 
     def test_offline_screenshots(self):
         r = SnapEngageNode().render(Context({
             'snapengage_offline_screenshots': False,
         }))
-        self.assertTrue('SnapABug.showScreenshotOption(false);' in r, r)
+        assert 'SnapABug.showScreenshotOption(false);' in r
         with override_settings(SNAPENGAGE_OFFLINE_SCREENSHOTS=False):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.showScreenshotOption(false);' in r, r)
+            assert 'SnapABug.showScreenshotOption(false);' in r
 
     def test_sounds(self):
         r = SnapEngageNode().render(Context({'snapengage_sounds': False}))
-        self.assertTrue('SnapABug.allowChatSound(false);' in r, r)
+        assert 'SnapABug.allowChatSound(false);' in r
         with override_settings(SNAPENGAGE_SOUNDS=False):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.allowChatSound(false);' in r, r)
+            assert 'SnapABug.allowChatSound(false);' in r
 
     @override_settings(SNAPENGAGE_READONLY_EMAIL=False)
     def test_email(self):
         r = SnapEngageNode().render(Context({
             'snapengage_email': 'test@example.com',
         }))
-        self.assertTrue('SnapABug.setUserEmail("test@example.com");' in r, r)
+        assert 'SnapABug.setUserEmail("test@example.com");' in r
 
     def test_email_readonly(self):
         r = SnapEngageNode().render(Context({
             'snapengage_email': 'test@example.com',
             'snapengage_readonly_email': True,
         }))
-        self.assertTrue('SnapABug.setUserEmail("test@example.com",true);' in r, r)
+        assert 'SnapABug.setUserEmail("test@example.com",true);' in r
         with override_settings(SNAPENGAGE_READONLY_EMAIL=True):
             r = SnapEngageNode().render(Context({
                 'snapengage_email': 'test@example.com',
             }))
-            self.assertTrue('SnapABug.setUserEmail("test@example.com",true);' in r, r)
+            assert 'SnapABug.setUserEmail("test@example.com",true);' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = SnapEngageNode().render(Context({
             'user': User(username='test', email='test@example.com'),
         }))
-        self.assertTrue('SnapABug.setUserEmail("test@example.com");' in r, r)
+        assert 'SnapABug.setUserEmail("test@example.com");' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = SnapEngageNode().render(Context({
             'user': AnonymousUser(),
         }))
-        self.assertFalse('SnapABug.setUserEmail(' in r, r)
+        assert 'SnapABug.setUserEmail(' not in r
 
     def test_language(self):
         r = SnapEngageNode().render(Context({'snapengage_locale': 'fr'}))
-        self.assertTrue('SnapABug.setLocale("fr");' in r, r)
+        assert 'SnapABug.setLocale("fr");' in r
         with override_settings(SNAPENGAGE_LOCALE='fr'):
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setLocale("fr");' in r, r)
+            assert 'SnapABug.setLocale("fr");' in r
 
     def test_automatic_language(self):
         real_get_language = translation.get_language
         try:
             translation.get_language = lambda: 'fr-ca'
             r = SnapEngageNode().render(Context())
-            self.assertTrue('SnapABug.setLocale("fr_CA");' in r, r)
+            assert 'SnapABug.setLocale("fr_CA");' in r
         finally:
             translation.get_language = real_get_language

--- a/tests/unit/test_tag_spring_metrics.py
+++ b/tests/unit/test_tag_spring_metrics.py
@@ -11,6 +11,8 @@ from analytical.templatetags.spring_metrics import SpringMetricsNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(SPRING_METRICS_TRACKING_ID='12345678')
 class SpringMetricsTagTestCase(TagTestCase):
@@ -20,39 +22,41 @@ class SpringMetricsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('spring_metrics', 'spring_metrics')
-        self.assertTrue("_springMetq.push(['id', '12345678']);" in r, r)
+        assert "_springMetq.push(['id', '12345678']);" in r
 
     def test_node(self):
         r = SpringMetricsNode().render(Context({}))
-        self.assertTrue("_springMetq.push(['id', '12345678']);" in r, r)
+        assert "_springMetq.push(['id', '12345678']);" in r
 
     @override_settings(SPRING_METRICS_TRACKING_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, SpringMetricsNode)
+        with pytest.raises(AnalyticalException):
+            SpringMetricsNode()
 
     @override_settings(SPRING_METRICS_TRACKING_ID='123xyz')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, SpringMetricsNode)
+        with pytest.raises(AnalyticalException):
+            SpringMetricsNode()
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = SpringMetricsNode().render(Context({
             'user': User(email='test@test.com'),
         }))
-        self.assertTrue("_springMetq.push(['setdata', {'email': 'test@test.com'}]);" in r, r)
+        assert "_springMetq.push(['setdata', {'email': 'test@test.com'}]);" in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = SpringMetricsNode().render(Context({'user': AnonymousUser()}))
-        self.assertFalse("_springMetq.push(['setdata', {'email':" in r, r)
+        assert "_springMetq.push(['setdata', {'email':" not in r
 
     def test_custom(self):
         r = SpringMetricsNode().render(Context({
             'spring_metrics_var1': 'val1',
             'spring_metrics_var2': 'val2',
         }))
-        self.assertTrue("_springMetq.push(['setdata', {'var1': 'val1'}]);" in r, r)
-        self.assertTrue("_springMetq.push(['setdata', {'var2': 'val2'}]);" in r, r)
+        assert "_springMetq.push(['setdata', {'var1': 'val1'}]);" in r
+        assert "_springMetq.push(['setdata', {'var2': 'val2'}]);" in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -60,6 +64,5 @@ class SpringMetricsTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = SpringMetricsNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Spring Metrics disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Spring Metrics disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_uservoice.py
+++ b/tests/unit/test_tag_uservoice.py
@@ -4,6 +4,7 @@ Tests for the UserVoice tags and filters.
 
 from django.template import Context
 from django.test.utils import override_settings
+import pytest
 
 from analytical.templatetags.uservoice import UserVoiceNode
 from utils import TagTestCase
@@ -16,58 +17,55 @@ class UserVoiceTagTestCase(TagTestCase):
     Tests for the ``uservoice`` template tag.
     """
 
-    def assertIn(self, element, container):
-        try:
-            super(TagTestCase, self).assertIn(element, container)
-        except AttributeError:
-            self.assertTrue(element in container)
-
     def test_node(self):
         r = UserVoiceNode().render(Context())
-        self.assertIn("widget.uservoice.com/abcdefghijklmnopqrst.js", r)
+        assert "widget.uservoice.com/abcdefghijklmnopqrst.js" in r
 
     def test_tag(self):
         r = self.render_tag('uservoice', 'uservoice')
-        self.assertIn("widget.uservoice.com/abcdefghijklmnopqrst.js", r)
+        assert "widget.uservoice.com/abcdefghijklmnopqrst.js" in r
 
     @override_settings(USERVOICE_WIDGET_KEY=None)
     def test_no_key(self):
-        self.assertRaises(AnalyticalException, UserVoiceNode)
+        with pytest.raises(AnalyticalException):
+            UserVoiceNode()
 
     @override_settings(USERVOICE_WIDGET_KEY='abcdefgh ijklmnopqrst')
     def test_invalid_key(self):
-        self.assertRaises(AnalyticalException, UserVoiceNode)
+        with pytest.raises(AnalyticalException):
+            UserVoiceNode()
 
     @override_settings(USERVOICE_WIDGET_KEY='')
     def test_empty_key(self):
-        self.assertRaises(AnalyticalException, UserVoiceNode)
+        with pytest.raises(AnalyticalException):
+            UserVoiceNode()
 
     def test_overridden_key(self):
         vars = {'uservoice_widget_key': 'defghijklmnopqrstuvw'}
         r = UserVoiceNode().render(Context(vars))
-        self.assertIn("widget.uservoice.com/defghijklmnopqrstuvw.js", r)
+        assert "widget.uservoice.com/defghijklmnopqrstuvw.js" in r
 
     @override_settings(USERVOICE_WIDGET_OPTIONS={'key1': 'val1'})
     def test_options(self):
         r = UserVoiceNode().render(Context())
-        self.assertIn("""UserVoice.push(['set', {"key1": "val1"}]);""", r)
+        assert """UserVoice.push(['set', {"key1": "val1"}]);""" in r
 
     @override_settings(USERVOICE_WIDGET_OPTIONS={'key1': 'val1'})
     def test_override_options(self):
         data = {'uservoice_widget_options': {'key1': 'val2'}}
         r = UserVoiceNode().render(Context(data))
-        self.assertIn("""UserVoice.push(['set', {"key1": "val2"}]);""", r)
+        assert """UserVoice.push(['set', {"key1": "val2"}]);""" in r
 
     def test_auto_trigger_default(self):
         r = UserVoiceNode().render(Context())
-        self.assertTrue("UserVoice.push(['addTrigger', {}]);" in r, r)
+        assert "UserVoice.push(['addTrigger', {}]);" in r
 
     @override_settings(USERVOICE_ADD_TRIGGER=False)
     def test_auto_trigger(self):
         r = UserVoiceNode().render(Context())
-        self.assertFalse("UserVoice.push(['addTrigger', {}]);" in r, r)
+        assert "UserVoice.push(['addTrigger', {}]);" not in r
 
     @override_settings(USERVOICE_ADD_TRIGGER=False)
     def test_auto_trigger_custom_win(self):
         r = UserVoiceNode().render(Context({'uservoice_add_trigger': True}))
-        self.assertTrue("UserVoice.push(['addTrigger', {}]);" in r, r)
+        assert "UserVoice.push(['addTrigger', {}]);" in r

--- a/tests/unit/test_tag_woopra.py
+++ b/tests/unit/test_tag_woopra.py
@@ -11,6 +11,8 @@ from analytical.templatetags.woopra import WoopraNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(WOOPRA_DOMAIN='example.com')
 class WoopraTagTestCase(TagTestCase):
@@ -20,32 +22,33 @@ class WoopraTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('woopra', 'woopra')
-        self.assertTrue('var woo_settings = {"domain": "example.com"};' in r, r)
+        assert 'var woo_settings = {"domain": "example.com"};' in r
 
     def test_node(self):
         r = WoopraNode().render(Context({}))
-        self.assertTrue('var woo_settings = {"domain": "example.com"};' in r, r)
+        assert 'var woo_settings = {"domain": "example.com"};' in r
 
     @override_settings(WOOPRA_DOMAIN=None)
     def test_no_domain(self):
-        self.assertRaises(AnalyticalException, WoopraNode)
+        with pytest.raises(AnalyticalException):
+            WoopraNode()
 
     @override_settings(WOOPRA_DOMAIN='this is not a domain')
     def test_wrong_domain(self):
-        self.assertRaises(AnalyticalException, WoopraNode)
+        with pytest.raises(AnalyticalException):
+            WoopraNode()
 
     @override_settings(WOOPRA_IDLE_TIMEOUT=1234)
     def test_idle_timeout(self):
         r = WoopraNode().render(Context({}))
-        self.assertTrue('var woo_settings = '
-                        '{"domain": "example.com", "idle_timeout": "1234"};' in r, r)
+        assert 'var woo_settings = {"domain": "example.com", "idle_timeout": "1234"};' in r
 
     def test_custom(self):
         r = WoopraNode().render(Context({
             'woopra_var1': 'val1',
             'woopra_var2': 'val2',
         }))
-        self.assertTrue('var woo_visitor = {"var1": "val1", "var2": "val2"};' in r, r)
+        assert 'var woo_visitor = {"var1": "val1", "var2": "val2"};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_name_and_email(self):
@@ -55,13 +58,13 @@ class WoopraTagTestCase(TagTestCase):
                          last_name='Lastname',
                          email="test@example.com"),
         }))
-        self.assertTrue('var woo_visitor = '
-                        '{"email": "test@example.com", "name": "Firstname Lastname"};' in r, r)
+        assert 'var woo_visitor = '
+        '{"email": "test@example.com", "name": "Firstname Lastname"};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_username_no_email(self):
         r = WoopraNode().render(Context({'user': User(username='test')}))
-        self.assertTrue('var woo_visitor = {"name": "test"};' in r, r)
+        assert 'var woo_visitor = {"name": "test"};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_no_identify_when_explicit_name(self):
@@ -69,7 +72,7 @@ class WoopraTagTestCase(TagTestCase):
             'woopra_name': 'explicit',
             'user': User(username='implicit'),
         }))
-        self.assertTrue('var woo_visitor = {"name": "explicit"};' in r, r)
+        assert 'var woo_visitor = {"name": "explicit"};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_no_identify_when_explicit_email(self):
@@ -77,12 +80,12 @@ class WoopraTagTestCase(TagTestCase):
             'woopra_email': 'explicit',
             'user': User(username='implicit'),
         }))
-        self.assertTrue('var woo_visitor = {"email": "explicit"};' in r, r)
+        assert 'var woo_visitor = {"email": "explicit"};' in r
 
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify_anonymous_user(self):
         r = WoopraNode().render(Context({'user': AnonymousUser()}))
-        self.assertTrue('var woo_visitor = {};' in r, r)
+        assert 'var woo_visitor = {};' in r
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -90,6 +93,5 @@ class WoopraTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = WoopraNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Woopra disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Woopra disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_tag_yandex_metrica.py
+++ b/tests/unit/test_tag_yandex_metrica.py
@@ -11,6 +11,8 @@ from analytical.templatetags.yandex_metrica import YandexMetricaNode
 from utils import TagTestCase
 from analytical.utils import AnalyticalException
 
+import pytest
+
 
 @override_settings(YANDEX_METRICA_COUNTER_ID='12345678')
 class YandexMetricaTagTestCase(TagTestCase):
@@ -20,19 +22,21 @@ class YandexMetricaTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('yandex_metrica', 'yandex_metrica')
-        self.assertTrue("w.yaCounter12345678 = new Ya.Metrika" in r, r)
+        assert "w.yaCounter12345678 = new Ya.Metrika" in r
 
     def test_node(self):
         r = YandexMetricaNode().render(Context({}))
-        self.assertTrue("w.yaCounter12345678 = new Ya.Metrika" in r, r)
+        assert "w.yaCounter12345678 = new Ya.Metrika" in r
 
     @override_settings(YANDEX_METRICA_COUNTER_ID=None)
     def test_no_site_id(self):
-        self.assertRaises(AnalyticalException, YandexMetricaNode)
+        with pytest.raises(AnalyticalException):
+            YandexMetricaNode()
 
     @override_settings(YANDEX_METRICA_COUNTER_ID='1234abcd')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, YandexMetricaNode)
+        with pytest.raises(AnalyticalException):
+            YandexMetricaNode()
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
@@ -40,6 +44,5 @@ class YandexMetricaTagTestCase(TagTestCase):
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
         r = YandexMetricaNode().render(context)
-        self.assertTrue(r.startswith(
-                '<!-- Yandex.Metrica disabled on internal IP address'), r)
-        self.assertTrue(r.endswith('-->'), r)
+        assert r.startswith('<!-- Yandex.Metrica disabled on internal IP address')
+        assert r.endswith('-->')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,6 +18,8 @@ from analytical.utils import (
 )
 from utils import TestCase
 
+import pytest
+
 
 class SettingDeletedTestCase(TestCase):
 
@@ -27,7 +29,7 @@ class SettingDeletedTestCase(TestCase):
         Make sure using get_required_setting fails in the right place.
         """
 
-        with self.assertRaisesRegex(AnalyticalException, "^USER_ID setting is not set$"):
+        with pytest.raises(AnalyticalException, match="USER_ID setting is not set"):
             get_required_setting("USER_ID", r"\d+", "invalid USER_ID")
 
 
@@ -43,27 +45,27 @@ class MyUser(AbstractBaseUser):
 class GetIdentityTestCase(TestCase):
     def test_custom_username_field(self):
         get_id = get_identity(Context({}), user=MyUser(identity='fake_id'))
-        self.assertEqual(get_id, 'fake_id')
+        assert get_id == 'fake_id'
 
 
 @override_settings(ANALYTICAL_DOMAIN="example.org")
 class GetDomainTestCase(TestCase):
     def test_get_service_domain_from_context(self):
         context = Context({'test_domain': 'example.com'})
-        self.assertEqual(get_domain(context, 'test'), 'example.com')
+        assert get_domain(context, 'test') == 'example.com'
 
     def test_get_analytical_domain_from_context(self):
         context = Context({'analytical_domain': 'example.com'})
-        self.assertEqual(get_domain(context, 'test'), 'example.com')
+        assert get_domain(context, 'test') == 'example.com'
 
     @override_settings(TEST_DOMAIN="example.net")
     def test_get_service_domain_from_settings(self):
         context = Context()
-        self.assertEqual(get_domain(context, 'test'), 'example.net')
+        assert get_domain(context, 'test') == 'example.net'
 
     def test_get_analytical_domain_from_settings(self):
         context = Context()
-        self.assertEqual(get_domain(context, 'test'), 'example.org')
+        assert get_domain(context, 'test') == 'example.org'
 
 
 # FIXME: enable Django apps dynamically and enable test again
@@ -82,7 +84,7 @@ class InternalIpTestCase(TestCase):
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_no_internal_ip(self):
         context = Context()
-        self.assertFalse(is_internal_ip(context))
+        assert not is_internal_ip(context)
 
     @override_settings(INTERNAL_IPS=['1.1.1.1'])
     @override_settings(ANALYTICAL_INTERNAL_IPS=[])
@@ -90,39 +92,39 @@ class InternalIpTestCase(TestCase):
         req = HttpRequest()
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
-        self.assertFalse(is_internal_ip(context))
+        assert not is_internal_ip(context)
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
         req = HttpRequest()
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
-        self.assertTrue(is_internal_ip(context))
+        assert is_internal_ip(context)
 
     @override_settings(TEST_INTERNAL_IPS=['1.1.1.1'])
     def test_render_prefix_internal_ip(self):
         req = HttpRequest()
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
-        self.assertTrue(is_internal_ip(context, 'TEST'))
+        assert is_internal_ip(context, 'TEST')
 
     @override_settings(INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip_fallback(self):
         req = HttpRequest()
         req.META['REMOTE_ADDR'] = '1.1.1.1'
         context = Context({'request': req})
-        self.assertTrue(is_internal_ip(context))
+        assert is_internal_ip(context)
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip_forwarded_for(self):
         req = HttpRequest()
         req.META['HTTP_X_FORWARDED_FOR'] = '1.1.1.1'
         context = Context({'request': req})
-        self.assertTrue(is_internal_ip(context))
+        assert is_internal_ip(context)
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_different_internal_ip(self):
         req = HttpRequest()
         req.META['REMOTE_ADDR'] = '2.2.2.2'
         context = Context({'request': req})
-        self.assertFalse(is_internal_ip(context))
+        assert not is_internal_ip(context)


### PR DESCRIPTION
When looking at the code when it is formatted with Black there are a number of cases where it would be a bit more readable if plain pytest asserts were used. 

I've done a few files as an example. Is this wanted? Let me know what you think. 