### PR TITLE
allow to set identity_func by ANALYTICAL_IDENTITY_FUNC settings

### DIFF
--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -84,10 +84,12 @@ def get_identity(context, prefix=None, identity_func=None, user=None):
             if user is None:
                 user = get_user_from_context(context)
             if get_user_is_authenticated(user):
-                if identity_func is not None:
-                    return identity_func(user)
-                else:
+                identity_func = getattr(settings, 'ANALYTICAL_IDENTITY_FUNC',
+                                        identity_func)
+                if identity_func is None:
                     return user.get_username()
+                else:
+                    return identity_func(user)
         except (KeyError, AttributeError):
             pass
     return None

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -25,3 +25,17 @@ their default values.
     ``GOOGLE_ANALYTICS_INTERNAL_IPS`` to configure for Google Analytics.
 
     See :ref:`internal-ips`.
+
+.. data:: ANALYTICAL_IDENTITY_FUNC
+
+    Default: Identity function dependent on provider
+
+    A function that returns the identity of the given user. This overrides the
+    default settings of different providers.
+
+    E.g. Google has in its conditions for enabling UserID the requirement, that prohibits
+    sending personal data (such as an e-mail address) to analytics.
+    If e-mail address is used as username, using GTag would break the requirements.
+
+    In such case add uuid field to the user and set ```ANALYTICAL_IDENTITY_FUNC``` to
+    ```lambda user: user.uuid```

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,6 +34,7 @@ class SettingDeletedTestCase(TestCase):
 
 class MyUser(AbstractBaseUser):
     identity = models.CharField(max_length=50)
+    name = models.CharField(max_length=50)
     USERNAME_FIELD = 'identity'
 
     class Meta:
@@ -45,6 +46,11 @@ class GetIdentityTestCase(TestCase):
     def test_custom_username_field(self):
         get_id = get_identity(Context({}), user=MyUser(identity='fake_id'))
         assert get_id == 'fake_id'
+
+    @override_settings(ANALYTICAL_IDENTITY_FUNC=lambda user: f"{user.name} ({user.identity})")
+    def test_custom_username_field_identity_func(self):
+        get_id = get_identity(Context({}), user=MyUser(identity='fake_id', name='fake_name'))
+        assert get_id == 'fake_name (fake_id)'
 
 
 @override_settings(ANALYTICAL_DOMAIN="example.org")


### PR DESCRIPTION
Google has in it's conditions for enabling UserID requirement, that prohibits sending personal data (such as e-mail address) to analytics.
I am using e-mail address as username, so using GTag would break the requirements for me.

This enables me to set user UUID for the UserID parameter.