### PR TITLE
Fix #141 and add custom event trigger binding support

### DIFF
--- a/analytical/context_providers/matomo.py
+++ b/analytical/context_providers/matomo.py
@@ -1,0 +1,34 @@
+import utils
+from django.conf import settings
+
+def matomo_consent_provider(request):
+    """
+    Add Mamoto consent script to the requests context.
+    :Cases:
+        - If MATOMO_REQURE_CONSENT is True OR If ALWAYS_TRACK_REGISTERED True == continue on
+        - If ALWAYS_TRACK_REGISTERED is True AND the user is authenticated
+    """
+    # Do we require consent?
+    if getattr(settings, 'MATOMO_REQUIRE_CONSENT', False):
+        provide_script = True
+        if request.user.is_authenticated and not getattr(settings, "ALWAYS_TRACK_REGISTERED", True):
+            provide_script = False
+        if provide_script:
+            grant_class_name = getattr(settings, 'GRANT_CONSENT_TAG_CLASSNAME')
+            revoke_class_name = getattr(settings, 'REVOKE_CONSENT_CLASSNAME')
+            return {"consent_script":"""
+            %s;
+            %s
+            %s
+            """ % (
+                utils.build_paq_cmd('requireConsent'),
+                utils.get_event_bind_js(
+                    class_name=grant_class_name,
+                    matomo_event="rememberConsentGiven",
+                ),
+                utils.get_event_bind_js(
+                    class_name=revoke_class_name,
+                    matomo_event="forgetConsentGiven",
+                )
+            )}
+    return {'consent_script': ""}

--- a/analytical/context_providers/matomo.py
+++ b/analytical/context_providers/matomo.py
@@ -1,7 +1,7 @@
 import utils
 from django.conf import settings
 
-def matomo_consent_provider(request):
+def consent_provider(request):
     """
     Add Mamoto consent script to the requests context.
     :Cases:

--- a/analytical/context_providers/matomo.py
+++ b/analytical/context_providers/matomo.py
@@ -4,9 +4,6 @@ from django.conf import settings
 def consent_provider(request):
     """
     Add Mamoto consent script to the requests context.
-    :Cases:
-        - If MATOMO_REQURE_CONSENT is True OR If ALWAYS_TRACK_REGISTERED True == continue on
-        - If ALWAYS_TRACK_REGISTERED is True AND the user is authenticated
     """
     # Do we require consent?
     if getattr(settings, 'MATOMO_REQUIRE_CONSENT', False):

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -167,8 +167,8 @@ class AnalyticalException(Exception):
 def build_paq_cmd(cmd, args=[]):
     """
     :Args:
-        - cmd -> The command to be pushed to paq (i.e enableHeartbeatTimer or contentInteraction)
-        - args -> Arguments to be added to the paq command. This is mainly
+        - cmd: The command to be pushed to paq (i.e enableHeartbeatTimer or contentInteraction)
+        - args: Arguments to be added to the paq command. This is mainly
             used when building commands to be used on manual event trigger.
         
     :Returns:
@@ -176,12 +176,12 @@ def build_paq_cmd(cmd, args=[]):
     """
     def __to_js_arg(arg):
         """
+        Turn 'arg' into its javascript counter-part
         :Args:
-            - arg: The variable (Matomo argument) to be converted to JS.
+            - arg: the argument that's to be passed to the array in _paq.push()
         :Return:
-            Javascript version of the passed arg parameter
+            The javascript counter-part to the argument that was passed
         """
-        # Recursively handle dictionaries
         if isinstance(arg, dict):
             arg_cpy = deepcopy(arg)
             for k, v in arg_cpy.items():
@@ -196,18 +196,20 @@ def build_paq_cmd(cmd, args=[]):
         elif isinstance(arg, list):
             for elem_idx in range(len(arg)):
                 arg[elem_idx] = __to_js_arg(arg[elem_idx])
+
         return arg
 
-    paq = "_paq.push(['%s', " % (cmd)
+    paq = "_paq.push(['%s'" % (cmd)
     if len(args) > 0:
+        paq += ", "
         for arg_idx in range(len(args)):
             current_arg = __to_js_arg(args[arg_idx])
-            no_quotes = type(current_arg) in [bool, dict, list]
+            no_quotes = type(current_arg) in [bool, int, dict, list]
             if arg_idx == len(args)-1:
                 if no_quotes:
-                    segment = "%s])" % (current_arg)
+                    segment = "%s]);" % (current_arg)
                 else:
-                    segment = "'%s'])" % (current_arg)
+                    segment = "'%s']);" % (current_arg)
             else:
                 if no_quotes:
                     segment = "%s, "% (current_arg)
@@ -215,7 +217,7 @@ def build_paq_cmd(cmd, args=[]):
                     segment = "'%s', " % (current_arg)
             paq += segment
     else:
-        paq += "])"
+        paq += "]);"        
     return paq
 
 def get_event_bind_js(
@@ -248,4 +250,3 @@ def get_event_bind_js(
     }}
     """ % (class_name, js_event, build_paq_cmd(matomo_event, matomo_args))
     return script
-

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -215,3 +215,4 @@ def get_event_bind_js(
     }}
     """ % (class_name, js_event, build_paq_cmd(matomo_event, matomo_args))
     return script
+

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -163,3 +163,55 @@ class AnalyticalException(Exception):
     be silenced in templates.
     """
     silent_variable_failure = True
+
+def build_paq_cmd(cmd, args=[]):
+    """
+    :Args:
+        - cmd -> The command to be pushed to paq (i.e enableHeartbeatTimer or contentInteraction)
+        - args -> Arguments to be added to the paq command. This is mainly
+            used when building commands to be used on manual event trigger.
+        
+    :Returns:
+        A complete '_paq.push([])' command in string form
+    """
+    paq = "_paq.push(['%s', " % (cmd)
+    if len(args) > 0:
+        for arg_idx in range(len(args)):
+            if arg_idx == len(args)-1:
+                paq += "'%s'])" % (args[arg_idx])
+            else:
+                paq += "'%s', " % (args[arg_idx])
+    else:
+        paq += "])"
+    return paq
+
+def get_event_bind_js(
+    class_name, matomo_event,
+    matomo_args=[], js_event="onclick",
+    ):
+    """
+    Build a javascript command to bind an onClick event to some
+    element whose handler pushes something to _paq
+    :Args:
+        - class_name: Value of the 'class' attribute of the tag
+            the event is to be bound to.
+        - matomo_event: The matomo event to be pushed to _paq
+            such as enableHeartbeatTimer or contentInteraction
+        - matomo_args: The arguments to be passed with the matomo event
+            meaning
+    :Return:
+        A string of javascript that loops the elements found by 
+            document.getElementByClassName and binds the motomo event
+            to each element that was found
+    """
+    script = f"""
+    var elems = document.getElementByClassName('%s');
+    for (var i=0; i++; i < elems.length){{
+        elems[i].addEventListener('%s',
+            function(){{
+                %s;
+            }}
+        );
+    }}
+    """ % (class_name, js_event, build_paq_cmd(matomo_event, matomo_args))
+    return script

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -176,9 +176,10 @@ def build_paq_cmd(cmd, args=[]):
     """
     def __to_js_arg(arg):
         """
-        Turn the argument into a js variable.
-        True -> true
-        False -> false
+        :Args:
+            - arg: The variable (Matomo argument) to be converted to JS.
+        :Return:
+            Javascript version of the passed arg parameter
         """
         # Recursively handle dictionaries
         if isinstance(arg, dict):
@@ -187,18 +188,14 @@ def build_paq_cmd(cmd, args=[]):
                 arg.pop(k)
                 arg[__to_js_arg(k)] = __to_js_arg(v)
             return arg
-        # Handle bools
-        
         elif isinstance(arg, bool):
             if arg:
                 arg = "true"
             else:
                 arg = "false"
-        # Handle lists
         elif isinstance(arg, list):
             for elem_idx in range(len(arg)):
                 arg[elem_idx] = __to_js_arg(arg[elem_idx])
-
         return arg
 
     paq = "_paq.push(['%s', " % (cmd)


### PR DESCRIPTION
This should work to make Matomo respect consent.
I created two new utility functions, one builds paq commands, the other builds javascript to bind an event listener to elements with a certain class name. That will allow users to make their own custom template tags then use `analytical.utils.get_event_bind_js()` to bind events to their elements.