### PR TITLE
Add Python 3.10 and drop Django 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     # Python/Django combinations that are officially supported
-    py{36,37,38,39}-django{22,31,32}
-    py{38,39}-django{40}
+    py{36,37,38,39}-django{22,31}
+    py{36,37,38,39,310}-django{32}
+    py{38,39,310}-django{40}
     py37-{flake8,bandit,readme,docs,isort}
 
 [testenv]
@@ -25,6 +26,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv:py37-bandit]
 description = PyCQA security linter

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     # Python/Django combinations that are officially supported
-    py{36,37,38,39}-django{22,31}
+    py{36,37,38,39}-django{22}
     py{36,37,38,39,310}-django{32}
     py{38,39,310}-django{40}
     py37-{flake8,bandit,readme,docs,isort}


### PR DESCRIPTION
Hey, hope all is well. 

This PR adds Python 3.10 supprt and also drops support from Django 3.1 which is now EOL. 

Following review and merge of this do you think we could issue a new release to confirm support of these new versions? 