### PR TITLE
Rename default branch (master ➜ main)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,10 +3,10 @@ name: Check
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   python-django:

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ an asynchronous version of the Javascript code if possible.
 .. |build-status| image:: https://github.com/jazzband/django-analytical/workflows/Test/badge.svg
    :target: https://github.com/jazzband/django-analytical/actions
    :alt: GitHub Actions
-.. |coverage| image:: https://codecov.io/gh/jazzband/django-analytical/branch/master/graph/badge.svg
+.. |coverage| image:: https://codecov.io/gh/jazzband/django-analytical/branch/main/graph/badge.svg
    :alt: Test coverage
    :target: https://codecov.io/gh/jazzband/django-analytical
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/django-analytical.svg
@@ -37,7 +37,7 @@ an asynchronous version of the Javascript code if possible.
    :alt: Python versions
 .. |license| image:: https://img.shields.io/pypi/l/django-analytical.svg
    :alt: Software license
-   :target: https://github.com/jazzband/django-analytical/blob/master/LICENSE.txt
+   :target: https://github.com/jazzband/django-analytical/blob/main/LICENSE.txt
 .. |gitter| image:: https://img.shields.io/gitter/room/jazzband/django-analytical.svg
    :alt: Gitter chat room
    :target: https://gitter.im/jazzband/django-analytical

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     python_requires='>=3.6',
     platforms=['any'],
     url='https://github.com/jazzband/django-analytical',
-    download_url='https://github.com/jazzband/django-analytical/archive/master.zip',
+    download_url='https://github.com/jazzband/django-analytical/archive/main.zip',
     project_urls={
         'Documentation': 'https://django-analytical.readthedocs.io/',
     },


### PR DESCRIPTION
Following the example of other popular free software projects, we also rename our default branch to remove terminology stemming from colonialism and slavery.

Closes #204