### PR TITLE
Use pathlib instead of os.path (we only support Python 3.6+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-import os
+"""
+Packaging setup for django-analytical.
+"""
+
+from pathlib import Path
 
 from setuptools import setup
 
@@ -6,7 +10,7 @@ import analytical as package
 
 
 def read_file(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return (Path(__file__).resolve().parent / fname).open().read()
 
 
 setup(


### PR DESCRIPTION
pathlib's Path is the more elegant, object-oriented approach for path operations, available since Python 3.6.

We have dropped support for Python < 3.6 for quite a while, so using it for installing the package should be fine.