### PR TITLE
Use context manager for file reading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ import analytical as package
 
 
 def read_file(fname):
-    return (Path(__file__).resolve().parent / fname).open().read()
+    """Read content of a file in project folder."""
+    with (Path(__file__).resolve().parent / fname).open() as file:
+        return file.read()
 
 
 setup(


### PR DESCRIPTION
We better close the file explicitly after reading. A context manager does it for us in an elegant fashion.

Follow-up on #207.