### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+Version 3.1.0
+-------------
+* Rename default branch from master to main (Peter Bittner, Jannis Leidel)
+* Modernize packaging setup, add pyproject.toml (Peter Bittner)
+* Integrate isort, reorganize imports (David Smith)
+* Refactor test suite from Python unit tests to Pytest (David Smith)
+* Add Heap integration (Garrett Coakley)
+* Drop Django 3.1, cover Django 4.0 and Python 3.10 in test suite (David Smith)
+
 Version 3.0.0
 -------------
 * Add support for Lucky Orange (Peter Bittner)

--- a/analytical/__init__.py
+++ b/analytical/__init__.py
@@ -4,6 +4,5 @@ Analytics service integration for Django projects
 
 __author__ = "Joost Cassee"
 __email__ = "joost@cassee.net"
-__version__ = "3.0.0"
-__copyright__ = "Copyright (C) 2011-2020 Joost Cassee and contributors"
-__license__ = "MIT"
+__version__ = "3.1.0"
+__copyright__ = "Copyright (C) 2011-2022 Joost Cassee and contributors"

--- a/analytical/__init__.py
+++ b/analytical/__init__.py
@@ -5,4 +5,4 @@ Analytics service integration for Django projects
 __author__ = "Joost Cassee"
 __email__ = "joost@cassee.net"
 __version__ = "3.1.0"
-__copyright__ = "Copyright (C) 2011-2022 Joost Cassee and contributors"
+__copyright__ = "Copyright (C) 2011 Joost Cassee and contributors"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ def read_file(filename):
 setup(
     name='django-analytical',
     version=package.__version__,
-    license=package.__license__,
     description=package.__doc__.strip(),
     long_description=read_file('README.rst'),
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Updated the change log  and removed optional license field from metadata, as [recommended in the packaging guide](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#license).