### PR TITLE
Add the missing get_identity prefix to google_analytics_gtag, test it

### DIFF
--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -57,7 +57,7 @@ class GoogleAnalyticsGTagNode(Node):
     def render(self, context):
         other_fields = {}
 
-        identity = get_identity(context)
+        identity = get_identity(context, 'google_analytics_gtag')
         if identity is not None:
             other_fields['user_id'] = identity
 

--- a/tests/unit/test_tag_google_analytics_gtag.py
+++ b/tests/unit/test_tag_google_analytics_gtag.py
@@ -73,7 +73,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_identity_context_general(self):
         """
-        The user_id variable must be set according to analyitical_identity variable in the context.
+        The user_id variable must be set according to analytical_identity variable in the context.
         """
         r = GoogleAnalyticsGTagNode().render(Context({
             'analytical_identity': 'bar_analytical_identity',

--- a/tests/unit/test_tag_google_analytics_gtag.py
+++ b/tests/unit/test_tag_google_analytics_gtag.py
@@ -59,6 +59,28 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         r = GoogleAnalyticsGTagNode().render(Context({'user': User(username='test')}))
         assert "gtag('set', {'user_id': 'test'});" in r
 
+    def test_identity_context_specific_provider(self):
+        """
+        The user_id variable must be set according to
+        google_analytics_gtag_identity variable in the context.
+        """
+        r = GoogleAnalyticsGTagNode().render(Context({
+            'google_analytics_gtag_identity': 'foo_gtag_identity',
+            'analytical_identity': 'bar_analytical_identity',
+            'user': User(username='test'),
+        }))
+        assert "gtag('set', {'user_id': 'foo_gtag_identity'});" in r
+
+    def test_identity_context_general(self):
+        """
+        The user_id variable must be set according to analyitical_identity variable in the context.
+        """
+        r = GoogleAnalyticsGTagNode().render(Context({
+            'analytical_identity': 'bar_analytical_identity',
+            'user': User(username='test'),
+        }))
+        assert "gtag('set', {'user_id': 'bar_analytical_identity'});" in r
+
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='G-12345678')
     def test_tag_with_measurement_id(self):
         r = self.render_tag('google_analytics_gtag', 'google_analytics_gtag')


### PR DESCRIPTION
Add the missing prefix in `get_identity()` in `google_analytics_gtag` and test it.

Change of docs and other tests will come in separate PRs.