### PR TITLE
docs: fix simple typo, convesions -> conversions

### DIFF
--- a/docs/services/spring_metrics.rst
+++ b/docs/services/spring_metrics.rst
@@ -2,7 +2,7 @@
 Spring Metrics -- conversion tracking
 =====================================
 
-`Spring Metrics`_ is a convesions analysis tool.  It shows you the top
+`Spring Metrics`_ is a conversions analysis tool.  It shows you the top
 converting sources, search keywords and landing pages.  The real-time
 dashboard shows you how customers interact with your website and how
 to increase conversion.


### PR DESCRIPTION
There is a small typo in docs/services/spring_metrics.rst.

Should read `conversions` rather than `convesions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md