### PR TITLE
Add Liveinternet

### DIFF
--- a/analytical/templatetags/liveinternet.py
+++ b/analytical/templatetags/liveinternet.py
@@ -1,0 +1,77 @@
+from django.template import Library, Node
+
+from analytical.utils import is_internal_ip, disable_html
+
+LIVEINTERNET_WITH_IMAGE = """
+<a href="https://www.liveinternet.ru/click"
+target="_blank"><img id="licnt515E" width="31" height="31" style="border:0" 
+title="LiveInternet"
+src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
+alt=""/></a><script>(function(d,s){d.getElementById("licnt515E").src=
+"https://counter.yadro.ru/hit?t50.6;r"+escape(d.referrer)+
+((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
+(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
+";h"+escape(d.title.substring(0,150))+";"+Math.random()})
+(document,screen)</script>
+"""
+
+LIVEINTERNET_CODE = """
+<script>
+new Image().src = "https://counter.yadro.ru/hit?r"+
+escape(document.referrer)+((typeof(screen)=="undefined")?"":
+";s"+screen.width+"*"+screen.height+"*"+(screen.colorDepth?
+screen.colorDepth:screen.pixelDepth))+";u"+escape(document.URL)+
+";h"+escape(document.title.substring(0,150))+
+";"+Math.random();
+</script>
+"""
+LIVEINTERNET_IMAGE = """
+<a href="https://www.liveinternet.ru/click"
+target="_blank"><img src="https://counter.yadro.ru/logo?50.6"
+title="LiveInternet"
+alt="" style="border:0" width="31" height="31"/>
+</a>
+"""
+
+register = Library()
+
+
+@register.tag
+def liveinternet(parser, token):
+    """
+    Body Liveinternet, full image and code template tag.
+
+    Render the body Javascript code and image for Liveinternet.
+    """
+    return LiveInternetNode(LIVEINTERNET_WITH_IMAGE, 'liveinternet_with_image')
+
+
+@register.tag
+def liveinternet_code(parser, token):
+    """
+    Top Liveinternet,code template tag.
+
+    Render the top Javascript code for Liveinternet.
+    """
+    return LiveInternetNode(LIVEINTERNET_CODE, 'liveinternet_code')
+
+
+@register.tag
+def liveinternet_img(parser, token):
+    """
+    Body Liveinternet image template tag.
+
+    Render the body Javascript code for Liveinternet.
+    """
+    return LiveInternetNode(LIVEINTERNET_IMAGE, 'liveinternet_image')
+
+
+class LiveInternetNode(Node):
+    def __init__(self, key, name):
+        self.key = key
+        self.name = name
+
+    def render(self, context):
+        if is_internal_ip(context):
+            return disable_html(self.key, self.name)
+        return LIVEINTERNET_CODE

--- a/docs/services/liveinternet.rst
+++ b/docs/services/liveinternet.rst
@@ -1,0 +1,60 @@
+==================================
+Liveinternet -- traffic analysis
+==================================
+
+
+`Liveinternet`_ is an analytics tool like as google analytics.
+
+.. _`Liveinternet`: https://www.liveinternet.ru/code/
+
+
+.. yandex-metrica-installation:
+
+Installation
+============
+
+To start using the Liveinternet integration, you must have installed the
+django-analytical package and have added the ``analytical`` application
+to :const:`INSTALLED_APPS` in your project :file:`settings.py` file.
+See :doc:`../install` for details.
+
+Next you need to add the Liveinternet template tag to your templates.
+
+The Liveinternet counter code is inserted into templates using a template
+tag.  Load the :mod:`liveinternet` template tag library and insert the
+:ttag:`liveinternet` tag.  To display as a single image combining a counter
+and the LiveInternet logo::
+
+    {% load liveinternet %}
+    <html>
+    <head>
+    ...
+    {% liveinternet %}
+    </head>
+    ...
+In the form of two images, one of which is a counter (transparent GIF size 1x1),
+and the other is the LiveInternet logo. This placement method will allow you to
+insert the code of the invisible counter at the beginning of the page, and the
+logo - where the design and content of the page allows.::
+
+    {% load liveinternet %}
+    <html>
+    <head>
+    ...
+    {% liveinternet_code %}
+    </head>
+    <body>
+    ...
+        {% liveinternet_img %}
+    ...
+    </body>
+
+
+Internal IP addresses
+---------------------
+
+Usually you do not want to track clicks from your development or
+internal IP addresses.  It takes the value of
+:const:`ANALYTICAL_INTERNAL_IPS` by default (which in turn is
+:const:`INTERNAL_IPS` by default).  See :ref:`identifying-visitors` for
+important information about detecting the visitor IP address.


### PR DESCRIPTION
Addition service [Liveinternet](https://www.liveinternet.ru/code). Several implementation options have been made as per the documentation:
1. in the form of a single image combining the counter and the LiveInternet logo
2. in the form of two images, one of which is a counter (transparent GIF size 1x1), and the other is the LiveInternet logo. This placement method will allow you to insert the code of the invisible counter at the beginning of the page, and the logo - where the design and content of the page allows.