### PR TITLE
Fixed gtag user_id setup and added support for custom dimensions

### DIFF
--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -1,7 +1,8 @@
 """
-Google Analytics template tags and filters, using the new analytics.js library.
+Google Analytics template tags and filters, using the new gtag.js library.
+https://developers.google.com/tag-platform/gtagjs/reference
 """
-
+import json
 import re
 
 from django.template import Library, Node, TemplateSyntaxError
@@ -21,12 +22,9 @@ SETUP_CODE = """
   function gtag(){{dataLayer.push(arguments);}}
   gtag('js', new Date());
 
-  {extra}
-  gtag('config', '{property_id}');
+  gtag('config', '{property_id}', {custom_dimensions});
 </script>
 """
-
-GTAG_SET_CODE = """gtag('set', {{'{key}': '{value}'}});"""
 
 register = Library()
 
@@ -55,18 +53,15 @@ class GoogleAnalyticsGTagNode(Node):
             'G-XXXXXXXX', 'DC-XXXXXXXX')''')
 
     def render(self, context):
-        other_fields = {}
+        custom_dimensions = {}
 
-        identity = get_identity(context, 'google_analytics_gtag')
+        identity = get_identity(context, prefix='google_analytics_gtag')
         if identity is not None:
-            other_fields['user_id'] = identity
+            custom_dimensions['user_id'] = identity
 
-        extra = '\n'.join([
-            GTAG_SET_CODE.format(key=key, value=value) for key, value in other_fields.items()
-        ])
         html = SETUP_CODE.format(
             property_id=self.property_id,
-            extra=extra,
+            custom_dimensions=json.dumps(custom_dimensions),
         )
         if is_internal_ip(context, 'GOOGLE_ANALYTICS'):
             html = disable_html(html, 'Google Analytics')

--- a/analytical/templatetags/google_analytics_gtag.py
+++ b/analytical/templatetags/google_analytics_gtag.py
@@ -53,7 +53,7 @@ class GoogleAnalyticsGTagNode(Node):
             'G-XXXXXXXX', 'DC-XXXXXXXX')''')
 
     def render(self, context):
-        custom_dimensions = {}
+        custom_dimensions = context.get('google_analytics_custom_dimensions', {})
 
         identity = get_identity(context, prefix='google_analytics_gtag')
         if identity is not None:

--- a/docs/services/google_analytics_gtag.rst
+++ b/docs/services/google_analytics_gtag.rst
@@ -117,3 +117,48 @@ or in the template:
     {% endwith %}
 
 .. _`Google Analytics conditions`: https://developers.google.com/analytics/solutions/crm-integration#user_id
+
+.. _google-analytics-custom-dimensions:
+
+Custom dimensions
+----------------
+
+As described in the Google Analytics `custom dimensions`_ documentation
+page, you can define custom dimensions which are variables specific to your
+business needs. These variables can include both custom event parameters as
+well as customer user properties. Using the template context variable
+``google_analytics_custom_dimensions``, you can let the :ttag:`google_analytics_gtag`
+pass custom dimensions to Google Analytics automatically. The ``google_analytics_custom_dimensions``
+variable must be set to a dictionary where the keys are the dimension names
+and the values are the dimension values. You can set the context variable in your
+view when you render a template containing the tracking code::
+
+    context = RequestContext({
+        'google_analytics_custom_dimensions': {
+                'gender': 'female',
+                'country': 'US',
+                'user_properties': {
+                    'age': 25
+                }
+            }
+        })
+    return some_template.render(context)
+
+Note that the ``user_properties`` key is used to pass user properties to Google
+Analytics. It's not necessary to always use this key, but that'd be the way of
+sending user properties to Google Analytics automatically.
+
+You may want to set custom dimensions in a context processor that you add
+to the :data:`TEMPLATE_CONTEXT_PROCESSORS` list in :file:`settings.py`::
+
+    def google_analytics_segment_language(request):
+        try:
+            return {'google_analytics_custom_dimensions': {'language': request.LANGUAGE_CODE}}
+        except AttributeError:
+            return {}
+
+Just remember that if you set the same context variable in the
+:class:`~django.template.context.RequestContext` constructor and in a
+context processor, the latter clobbers the former.
+
+.. _`custom dimensions`: https://support.google.com/analytics/answer/10075209

--- a/tests/unit/test_tag_google_analytics_gtag.py
+++ b/tests/unit/test_tag_google_analytics_gtag.py
@@ -106,3 +106,34 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         ) in r
         assert "gtag('js', new Date());" in r
         assert "gtag('config', 'DC-12345678', {});" in r
+
+    def test_tag_with_custom_dimensions(self):
+        r = GoogleAnalyticsGTagNode().render(Context({
+            'google_analytics_custom_dimensions': {
+                "dimension_1": "foo",
+                "dimension_2": "bar",
+                "user_properties": {
+                    "user_property_1": True,
+                    "user_property_2": "xyz",
+                }
+            },
+        }))
+        assert "gtag('config', 'UA-123456-7', {" \
+               "\"dimension_1\": \"foo\", " \
+               "\"dimension_2\": \"bar\", " \
+               "\"user_properties\": {" \
+               "\"user_property_1\": true, " \
+               "\"user_property_2\": \"xyz\"}});" in r
+
+    def test_tag_with_identity_and_custom_dimensions(self):
+        r = GoogleAnalyticsGTagNode().render(Context({
+            'google_analytics_gtag_identity': 'foo_gtag_identity',
+            'google_analytics_custom_dimensions': {
+                "dimension_1": "foo",
+                "dimension_2": "bar",
+            },
+        }))
+        assert "gtag('config', 'UA-123456-7', {" \
+               "\"dimension_1\": \"foo\", " \
+               "\"dimension_2\": \"bar\", " \
+               "\"user_id\": \"foo_gtag_identity\"});" in r

--- a/tests/unit/test_tag_google_analytics_gtag.py
+++ b/tests/unit/test_tag_google_analytics_gtag.py
@@ -16,7 +16,7 @@ from analytical.utils import AnalyticalException
 @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='UA-123456-7')
 class GoogleAnalyticsTagTestCase(TagTestCase):
     """
-    Tests for the ``google_analytics_js`` template tag.
+    Tests for the ``google_analytics_gtag`` template tag.
     """
 
     def test_tag(self):
@@ -25,7 +25,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
         ) in r
         assert "gtag('js', new Date());" in r
-        assert "gtag('config', 'UA-123456-7');" in r
+        assert "gtag('config', 'UA-123456-7', {});" in r
 
     def test_node(self):
         r = GoogleAnalyticsGTagNode().render(Context())
@@ -33,7 +33,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             '<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123456-7"></script>'
         ) in r
         assert "gtag('js', new Date());" in r
-        assert "gtag('config', 'UA-123456-7');" in r
+        assert "gtag('config', 'UA-123456-7', {});" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID=None)
     def test_no_property_id(self):
@@ -57,7 +57,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     @override_settings(ANALYTICAL_AUTO_IDENTIFY=True)
     def test_identify(self):
         r = GoogleAnalyticsGTagNode().render(Context({'user': User(username='test')}))
-        assert "gtag('set', {'user_id': 'test'});" in r
+        assert "gtag('config', 'UA-123456-7', {\"user_id\": \"test\"});" in r
 
     def test_identity_context_specific_provider(self):
         """
@@ -66,10 +66,9 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         """
         r = GoogleAnalyticsGTagNode().render(Context({
             'google_analytics_gtag_identity': 'foo_gtag_identity',
-            'analytical_identity': 'bar_analytical_identity',
             'user': User(username='test'),
         }))
-        assert "gtag('set', {'user_id': 'foo_gtag_identity'});" in r
+        assert "gtag('config', 'UA-123456-7', {\"user_id\": \"foo_gtag_identity\"});" in r
 
     def test_identity_context_general(self):
         """
@@ -79,7 +78,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             'analytical_identity': 'bar_analytical_identity',
             'user': User(username='test'),
         }))
-        assert "gtag('set', {'user_id': 'bar_analytical_identity'});" in r
+        assert "gtag('config', 'UA-123456-7', {\"user_id\": \"bar_analytical_identity\"});" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='G-12345678')
     def test_tag_with_measurement_id(self):
@@ -88,7 +87,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             '<script async src="https://www.googletagmanager.com/gtag/js?id=G-12345678"></script>'
         ) in r
         assert "gtag('js', new Date());" in r
-        assert "gtag('config', 'G-12345678');" in r
+        assert "gtag('config', 'G-12345678', {});" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='AW-1234567890')
     def test_tag_with_conversion_id(self):
@@ -97,7 +96,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             '<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1234567890"></script'
         ) in r
         assert "gtag('js', new Date());" in r
-        assert "gtag('config', 'AW-1234567890');" in r
+        assert "gtag('config', 'AW-1234567890', {});" in r
 
     @override_settings(GOOGLE_ANALYTICS_GTAG_PROPERTY_ID='DC-12345678')
     def test_tag_with_advertiser_id(self):
@@ -106,4 +105,4 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
             '<script async src="https://www.googletagmanager.com/gtag/js?id=DC-12345678"></script>'
         ) in r
         assert "gtag('js', new Date());" in r
-        assert "gtag('config', 'DC-12345678');" in r
+        assert "gtag('config', 'DC-12345678', {});" in r


### PR DESCRIPTION
Fixes #197 and #225

The correct way to send the `user_id` using the `gtag` has changed according to the [docs](https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtag). I have applied the required changes to the code to comply with the new specification via `gtag('config', ...)` as opposed to `gtag('set', ...)`.

In addition, I decided to take the chance to add support for sending [custom dimensions](https://support.google.com/analytics/answer/10075209) in GA4. Note that the custom dimensions are appended to the `gtag('config', ...)` command as a json serialized dictionary. There are (at least) two ways of adding custom dimensions that are sent along with every event with `gtag`. One is by using the [set](https://developers.google.com/tag-platform/gtagjs/reference#set) command and the other one is by using the [config](https://developers.google.com/tag-platform/gtagjs/reference#config) command. IMO, the latter is more convenient because you can add the `user_id` to the rest of dimensions and send it all together in the same command, so that's how I did it, but I'm happy to be convinced otherwise 😊 