### PR TITLE
Update CI setup.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,24 +10,7 @@ on:
 
 jobs:
   python-django:
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
-      matrix:
-        python-version:
-        - '3.6'
-        - '3.7'
-        - '3.8'
-        - '3.9'
-        - '3.10'
-        django-version:
-        - '2.2'
-        - '3.2'
-        - '4.0'
-        exclude:
-        - { django-version: '2.2', python-version: '3.10' }
-        - { django-version: '4.0', python-version: '3.6' }
-        - { django-version: '4.0', python-version: '3.7' }
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ envlist =
     flake8
     bandit
     # Python/Django combinations that are officially supported
-    py{36,37,38,39}-django{22}
-    py{36,37,38,39,310}-django{32}
-    py{38,39,310}-django{40}
+    py{36,37,38,39,310}-django32
+    py{38,39,310,311}-django{41,42}
     readme
     docs
 
@@ -17,21 +16,22 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
-    2.2: django22
     3.2: django32
-    4.0: django40
+    4.1: django41
+    4.2: django42
 
 [testenv]
 description = Unit tests
 deps =
     coverage[toml]
     pytest-django
-    django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
 commands =
     coverage run -m pytest {posargs}
     coverage xml


### PR DESCRIPTION
- remove support for Django 2.2
- remove support for Django 4.0
- add support for Django 4.2
- add support for Python 3.11 on supported Django versions