### PR TITLE
Use newer features of PyClean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ exclude = [".cache",".git",".github",".tox","build","dist","docs","tests"]
 [tool.black]
 color = true
 
-[tool.coverage.xml]
-output = "tests/coverage-report.xml"
-
 [tool.isort]
 color_output = true
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -68,11 +68,7 @@ commands =
 [testenv:clean]
 description = Clean up bytecode and build artifacts
 deps = pyclean
-commands =
-    pyclean {posargs:.}
-    rm -rf .tox/ build/ dist/ django_analytical.egg-info/ .coverage coverage.xml tests/coverage-report.xml tests/unittests-report.xml
-allowlist_externals =
-    rm
+commands = pyclean {posargs:. --debris --remove tests/unittests-report.xml --yes}
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist


### PR DESCRIPTION
PyClean now has a `--debris` option that allow us to simplify the related Tox configuration section.