### PR TITLE
Fix broken author credits in documentation, show coverage report in GHA jobs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-source = analytical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: release-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            release-
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,20 +39,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+        cache: pip
+        cache-dependency-path: |
+          **/pyproject.toml
 
     - name: Install dependencies
       run: |

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -23,8 +23,21 @@ considered to be a backward-incompatible change.
 Credits
 =======
 
-.. include:: ../AUTHORS.rst
+The django-analytical package was originally written by `Joost Cassee`_
+and is now maintained by `Peter Bittner`_ and the `Jazzband community`_.
+All known contributors are listed as ``authors`` in the `project metadata`_.
 
+Included JavaScript code snippets for integration of the analytics services
+were written by the respective service providers.
+
+The application was inspired by and uses ideas from Analytical_, Joshua
+Krall's all-purpose analytics front-end for Rails.
+
+.. _`Joost Cassee`: https://github.com/jcassee
+.. _`Peter Bittner`: https://github.com/bittner
+.. _`Jazzband community`: https://jazzband.co/
+.. _`project metadata`: https://github.com/jazzband/django-analytical/blob/main/pyproject.toml#L15-L60
+.. _`Analytical`: https://github.com/jkrall/analytical
 
 .. _helping-out:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,13 @@ dependencies = [
 Homepage = "https://github.com/jazzband/django-analytical"
 Documentation = "https://django-analytical.readthedocs.io/"
 
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+[tool.coverage.run]
+source = ["analytical"]
+
 [tool.pytest.ini_options]
 addopts = "--junitxml=tests/unittests-report.xml --color=yes --verbose"
 DJANGO_SETTINGS_MODULE = "tests.testproject.settings"

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     django52: Django>=5.2,<6.0
 commands =
     coverage run -m pytest {posargs}
+    coverage report
     coverage xml
 
 [testenv:audit]


### PR DESCRIPTION
Fixes a broken text include in the History chapter introduced via commit 7704f8c.

Removes the coverage configuration file and configures textual coverage report output in GHA test jobs.